### PR TITLE
Fix gh-pages

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,10 +2,10 @@ name: Build
 on:
   pull_request:
     branches:
-    - main
+    - master
   push:
     branches:
-    - main
+    - master
 jobs:
   build:
     name: Build
@@ -15,7 +15,7 @@ jobs:
     - name: Build
       run: make ci
     - name: Deploy
-      if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
+      if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/master' }}
       uses: peaceiris/actions-gh-pages@v3
       with:
         github_token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This PR fixes the GitHub pages build which was previously targeting the wrong branch. Some day we will probably rename the master branch, but for now, this gets the spec up and running.