### PR TITLE
Add monkey patch for Cross-Origin Resource Policy Internal Check

### DIFF
--- a/spec.bs
+++ b/spec.bs
@@ -181,4 +181,4 @@ Where it currently states
 
 Modify it to say
 
-> If origin is <a>same origin</a> with response's <a for=response>URL</a>'s <a for=url>origin</a>, and [=request/destination=] is not a fenced frame, then return allowed.
+> If origin is <a>same origin</a> with response's <a for=response>URL</a>'s <a for=url>origin</a>, and [=request/destination=] is not "<code>fencedframe</code>", then return <b>allowed</b>.

--- a/spec.bs
+++ b/spec.bs
@@ -165,3 +165,17 @@ The {{HTMLFencedFrameElement/src}} IDL attribute must [=reflect=] the respective
 <h3 id=dimension-attributes>Dimension attributes</h3>
 
 This section details monkeypatches to [[!HTML]]'s <a href="https://html.spec.whatwg.org/multipage/embedded-content-other.html#dimension-attributes">Dimension attributes</a> section. This section will be updated to include <{fencedframe}> in the list of elements that the <code>[=width=]</code> and <code>[=height=]</code> dimension attributes apply to.
+
+<h3 id=coep>Patching Cross-Origin Resource Policy Internal Check</h3>
+
+In [[!Fetch]]'s <a href="https://fetch.spec.whatwg.org/#cross-origin-resource-policy-internal-check">cross-origin resource policy internal check</a> steps, in the step
+
+> 5. Switch on policy:
+
+Where it currently states
+
+> If origin is same origin with response’s URL’s origin, then return allowed.
+
+Modify it to say
+
+> If origin is same origin with response’s URL’s origin, and [=request/destination=] is not a fenced frame, then return allowed.

--- a/spec.bs
+++ b/spec.bs
@@ -36,6 +36,9 @@ spec: html; urlPrefix: https://html.spec.whatwg.org/multipage/
     text: reflect; url: common-dom-interfaces.html#reflect
     text: width; url: embedded-content-other.html#attr-dim-width
     text: height; url: embedded-content-other.html#attr-dim-height
+spec: fetch; urlPrefix: https://fetch.spec.whatwg.org/
+  type: dfn
+    text: cross-origin resource policy internal check; url: #cross-origin-resource-policy-internal-check
 </pre>
 
 <style>
@@ -166,16 +169,16 @@ The {{HTMLFencedFrameElement/src}} IDL attribute must [=reflect=] the respective
 
 This section details monkeypatches to [[!HTML]]'s <a href="https://html.spec.whatwg.org/multipage/embedded-content-other.html#dimension-attributes">Dimension attributes</a> section. This section will be updated to include <{fencedframe}> in the list of elements that the <code>[=width=]</code> and <code>[=height=]</code> dimension attributes apply to.
 
-<h3 id=coep>Patching Cross-Origin Resource Policy Internal Check</h3>
+<h3 id=coep>Patching [=Cross-Origin Resource Policy Internal Check=]</h3>
 
-In [[!Fetch]]'s <a href="https://fetch.spec.whatwg.org/#cross-origin-resource-policy-internal-check">cross-origin resource policy internal check</a> steps, in the step
+In [[!Fetch]]'s [=cross-origin resource policy internal check=] steps, in the step
 
 > 5. Switch on policy:
 
 Where it currently states
 
-> If origin is same origin with response’s URL’s origin, then return allowed.
+> If origin is <a>same origin</a> with response's <a for=response>URL</a>'s <a for=url>origin</a>, then return <b>allowed</b>.
 
 Modify it to say
 
-> If origin is same origin with response’s URL’s origin, and [=request/destination=] is not a fenced frame, then return allowed.
+> If origin is <a>same origin</a> with response's <a for=response>URL</a>'s <a for=url>origin</a>, and [=request/destination=] is not a fenced frame, then return allowed.


### PR DESCRIPTION
This PR introduces a monkey patch that modifies the CORP internal check to not short circuit allow for same-origin URLs if the request's destination is a fenced frame. This will ensure that fenced frames always act like cross-origin frames, regardless of the origin of its src attribute.