### PR TITLE
Add monkey patch for fenced-frame-src directive

### DIFF
--- a/spec.bs
+++ b/spec.bs
@@ -169,7 +169,7 @@ The {{HTMLFencedFrameElement/src}} IDL attribute must [=reflect=] the respective
 
 This section details monkeypatches to [[!HTML]]'s <a href="https://html.spec.whatwg.org/multipage/embedded-content-other.html#dimension-attributes">Dimension attributes</a> section. This section will be updated to include <{fencedframe}> in the list of elements that the <code>[=width=]</code> and <code>[=height=]</code> dimension attributes apply to.
 
-<h3 id=new-request-destination>New fenced-frame-src [[!CSP]] [=directive=]</h3>
+<h3 id=new-csp-directive>New fenced-frame-src [[!CSP]] [=directive=]</h3>
 
 Fenced frames are a different element from an iframe. Therefore, using the <b><i>[=frame-src=]</i></b> directive wouldn't give web sites enough control over their CSP rules. Introduce a new [[!CSP]] [=directive=]: <b><i>fenced-frame-src</i></b>. The monkey-patched specification is printed below:
 

--- a/spec.bs
+++ b/spec.bs
@@ -233,7 +233,7 @@ In the <a href="https://w3c.github.io/webappsec-csp/#directive-fallback-list">di
 
 <h3 id=coep>Patching [=Cross-Origin Resource Policy Internal Check=]</h3>
 
-In [[!Fetch]]'s [=cross-origin resource policy internal check=] steps, in the step
+In [=Fetch=]'s [=cross-origin resource policy internal check=] steps, in the step
 
 > 5. Switch on policy:
 

--- a/spec.bs
+++ b/spec.bs
@@ -176,8 +176,8 @@ Fenced frames are a different element from an iframe. Therefore, using the <b><i
 
 <h4 id="directive-fenced-frame-src">`fenced-frame-src`</h4>
 
-The <dfn export>fenced-frame-src</dfn> directive restricts the URLs which may be loaded into
-<a>nested browsing contexts</a>. The syntax for the directive's name and value
+The <dfn>fenced-frame-src</dfn> directive restricts the URLs which may be loaded into
+a <span class="XXX">TODO: create a new browsing context, nested navigable, to be used here instead of the <a>nested browsing context</a> that is currently in use for other request destinations</span>. The syntax for the directive's name and value
 is described by the following ABNF:
 
 <pre>
@@ -185,14 +185,14 @@ is described by the following ABNF:
   directive-value = <a grammar>serialized-source-list</a>
 </pre>
 
-<div id="fenced-frame-src example" class="example">
+<div id="fenced-frame-src-example" class="example">
   Given a page with the following Content Security Policy:
   <pre>
     <a http-header>Content-Security-Policy</a>: <a>fenced-frame-src</a> https://example.com/
   </pre>
 
-  Fetches for the following code will return a network errors, as the URL
-  provided do not match `fenced-frame-src`'s <a>source list</a>:
+  Fetches for the following code will return a [=network error=], as the URL
+  provided does not match `fenced-frame-src`'s <a>source list</a>:
 
   <pre highlight="html">
     &lt;fencedframe src="https://example.org/"&gt;

--- a/spec.bs
+++ b/spec.bs
@@ -233,7 +233,7 @@ In the <a href="https://w3c.github.io/webappsec-csp/#directive-fallback-list">di
 
 <h3 id=coep>Patching [=Cross-Origin Resource Policy Internal Check=]</h3>
 
-In [=Fetch=]'s [=cross-origin resource policy internal check=] steps, in the step
+In [[!Fetch]]'s [=cross-origin resource policy internal check=] steps, in the step
 
 > 5. Switch on policy:
 

--- a/spec.bs
+++ b/spec.bs
@@ -38,8 +38,6 @@ spec: html; urlPrefix: https://html.spec.whatwg.org/multipage/
     text: height; url: embedded-content-other.html#attr-dim-height
 spec: fetch; urlPrefix: https://fetch.spec.whatwg.org/
   type: dfn
-    text: request; url: #concept-request
-    text: policy; url: #content-security-policy-object
     text: cross-origin resource policy internal check; url: #cross-origin-resource-policy-internal-check
 </pre>
 

--- a/spec.bs
+++ b/spec.bs
@@ -36,6 +36,10 @@ spec: html; urlPrefix: https://html.spec.whatwg.org/multipage/
     text: reflect; url: common-dom-interfaces.html#reflect
     text: width; url: embedded-content-other.html#attr-dim-width
     text: height; url: embedded-content-other.html#attr-dim-height
+spec: fetch; urlPrefix: https://fetch.spec.whatwg.org/
+  type: dfn
+    text: request; url: #concept-request
+    text: policy; url: #content-security-policy-object
 </pre>
 
 <style>
@@ -165,3 +169,63 @@ The {{HTMLFencedFrameElement/src}} IDL attribute must [=reflect=] the respective
 <h3 id=dimension-attributes>Dimension attributes</h3>
 
 This section details monkeypatches to [[!HTML]]'s <a href="https://html.spec.whatwg.org/multipage/embedded-content-other.html#dimension-attributes">Dimension attributes</a> section. This section will be updated to include <{fencedframe}> in the list of elements that the <code>[=width=]</code> and <code>[=height=]</code> dimension attributes apply to.
+
+<h3 id=new-request-destination>New fenced-frame-src [[!CSP]] [=directive=]</h3>
+
+Fenced frames are a different element from an iframe. Therefore, using the <b><i>[=frame-src=]</i></b> directive wouldn't give web sites enough control over their CSP rules. Introduce a new [[!CSP]] [=directive=]: <b><i>fenced-frame-src</i></b>. The monkey-patched specification is printed below:
+
+<h4 id="directive-fenced-frame-src">`fenced-frame-src`</h4>
+
+The <dfn export>fenced-frame-src</dfn> directive restricts the URLs which may be loaded into
+<a>nested browsing contexts</a>. The syntax for the directive's name and value
+is described by the following ABNF:
+
+<pre>
+  directive-name  = "fenced-frame-src"
+  directive-value = <a grammar>serialized-source-list</a>
+</pre>
+
+<div id="fenced-frame-src example" class="example">
+  Given a page with the following Content Security Policy:
+  <pre>
+    <a http-header>Content-Security-Policy</a>: <a>fenced-frame-src</a> https://example.com/
+  </pre>
+
+  Fetches for the following code will return a network errors, as the URL
+  provided do not match `fenced-frame-src`'s <a>source list</a>:
+
+  <pre highlight="html">
+    &lt;fencedframe src="https://example.org/"&gt;
+    &lt;/fencedframe&gt;
+  </pre>
+</div>
+
+The <a href="https://w3c.github.io/webappsec-csp/#frame-src-pre-request">Pre-request check</a> and <a href="https://w3c.github.io/webappsec-csp/#frame-src-post-request">Post-request check</a> will be the same as the <a href="https://w3c.github.io/webappsec-csp/#directive-frame-src">frame-src</a>'s check.
+
+<h4 id="default-src-amendment">Amending [=default-src=]</h4>
+
+The [=default-src=] directive's Example 7 and Example 8 will be amended. Where it says:
+
+<pre>
+  <a http-header>Content-Security-Policy</a>: <a>connect-src</a> <a grammar>'self'</a>;
+                           ...
+                           <a>worker-src</a> <a grammar>'self'</a>
+</pre>
+
+It will now say:
+
+<pre>
+  <a http-header>Content-Security-Policy</a>: <a>connect-src</a> <a grammar>'self'</a>;
+                           ...
+                           <a>fenced-frame-src</a> <a grammar>'self'</a>;
+                           ...
+                           <a>worker-src</a> <a grammar>'self'</a>
+</pre>
+
+<h4 id="fallback-list-amendment"> Amending The Directive Fallback List</h4>
+
+In the <a href="https://w3c.github.io/webappsec-csp/#directive-fallback-list">directive fallback list</a>, in step 1, add a new entry to the list:
+
+: "`fenced-frame-src`"
+::
+  1.  Return `<< "fenced-frame-src", "frame-src", "child-src", "default-src" >>`.


### PR DESCRIPTION
This PR introduces a monkey patch that adds a new CSP directive, "fenced-frame-src". This copies most of its behavior from the already existing "frame-src" directive.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/WICG/fenced-frame/pull/34.html" title="Last updated on Jul 17, 2022, 10:20 PM UTC (8b2b847)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/fenced-frame/34/28f6d0c...8b2b847.html" title="Last updated on Jul 17, 2022, 10:20 PM UTC (8b2b847)">Diff</a>