### PR TITLE
Revert "Add monkey patch for Cross-Origin Resource Policy Internal Check"

### DIFF
--- a/spec.bs
+++ b/spec.bs
@@ -36,9 +36,6 @@ spec: html; urlPrefix: https://html.spec.whatwg.org/multipage/
     text: reflect; url: common-dom-interfaces.html#reflect
     text: width; url: embedded-content-other.html#attr-dim-width
     text: height; url: embedded-content-other.html#attr-dim-height
-spec: fetch; urlPrefix: https://fetch.spec.whatwg.org/
-  type: dfn
-    text: cross-origin resource policy internal check; url: #cross-origin-resource-policy-internal-check
 </pre>
 
 <style>
@@ -168,17 +165,3 @@ The {{HTMLFencedFrameElement/src}} IDL attribute must [=reflect=] the respective
 <h3 id=dimension-attributes>Dimension attributes</h3>
 
 This section details monkeypatches to [[!HTML]]'s <a href="https://html.spec.whatwg.org/multipage/embedded-content-other.html#dimension-attributes">Dimension attributes</a> section. This section will be updated to include <{fencedframe}> in the list of elements that the <code>[=width=]</code> and <code>[=height=]</code> dimension attributes apply to.
-
-<h3 id=coep>Patching [=Cross-Origin Resource Policy Internal Check=]</h3>
-
-In [[!Fetch]]'s [=cross-origin resource policy internal check=] steps, in the step
-
-> 5. Switch on policy:
-
-Where it currently states
-
-> If origin is <a>same origin</a> with response's <a for=response>URL</a>'s <a for=url>origin</a>, then return <b>allowed</b>.
-
-Modify it to say
-
-> If origin is <a>same origin</a> with response's <a for=response>URL</a>'s <a for=url>origin</a>, and [=request/destination=] is not "<code>fencedframe</code>", then return <b>allowed</b>.


### PR DESCRIPTION
Reverts WICG/fenced-frame#31

This is not necessary since the potential 1-bit leak that this is patching is not an issue. See this document for reasoning why:
https://docs.google.com/document/d/1wQTnfpksl8i-UxQ-1eoFvKtYIgv7RVCNnM42YbJVEYQ/edit?usp=sharing