### PR TITLE
Local scheme navigation policy container patch

### DIFF
--- a/spec.bs
+++ b/spec.bs
@@ -22,6 +22,22 @@ WPT Display: open
 
 <pre class="link-defaults">
 </pre>
+<pre class="biblio">
+{
+  "private-network-access": {
+    "authors": [
+      "Titouan Rigoudy"
+    ],
+    "href": "https://wicg.github.io/private-network-access",
+    "title": "Private Network Access",
+    "status": "CG-DRAFT",
+    "publisher": "WICG",
+    "deliveredBy": [
+      "https://wicg.io/"
+    ]
+  }
+}
+</pre>
 <pre class="anchors">
 urlPrefix: https://www.ietf.org/rfc/rfc4122.txt
   type: dfn; text: urn uuid
@@ -151,9 +167,6 @@ spec: RFC8941; urlPrefix: https://www.rfc-editor.org/rfc/rfc8941.html
     text: structured header; url: #section-1
     for: structured header
       text: token; url: name-tokens
-spec: local-network-access; urlPrefix: https://wicg.github.io/local-network-access/
-  type: dfn
-    text: Integration with HTML; url: integration-html
 spec: permissions-policy; urlPrefix: https://w3c.github.io/webappsec-permissions-policy
   type: dfn
     text: ASCII-serialized policy directive; url: serialized-policy-directive
@@ -2335,31 +2348,16 @@ achieve the outcomes described in the above explanatory content.
 
 <h3 id=private-network-access-monkeypatch>Private network access</h3>
 
-Private network access is a security feature that allows you to control which apps on your device
-can access your local network. On creation, regular iframes can inherit their policy container from
-the navigation initiator, while fenced frames explicitly do not. While this prevents information
-from leaking from an embedder to a fenced frame, this results in a policy container being created
-that causes subresource requests to not do private network access checks. This section patches the
-local network access spec to have subresources be subject to those checks.
+[[Private-Network-Access]] is a security feature that allows you to control which web applications
+on can make [=local network requests=]. On creation, <{iframe}>s inherit their policy container from
+the navigation initiator, while <{fencedframe}>s explicitly do not. While this prevents information
+from leaking into a <{fencedframe}> from its embedder, it also results in a
+[=Document/policy container=] for {{Document}}s inside of a <{fencedframe}> being created that
+causes [=subresource requests=] to not do private network access checks. This section patches the
+[[Private-Network-Access]] specification to have subresources be subject to those checks.
 
-<div algorithm=pna-html-changes>
-  Modify the [=Integration with HTML=] section. Rewrite step 3 to read:
-
-  3. An additional step is added to the [=create a policy container from a fetch response=]
-    algorithm:
-
-    1. If |environment| is not null, |environment|'s [=environment/target browsing context=] is not
-      null, and |environment|'s [=environment/target browsing context=]'s [=browsing context/active
-      document=]'s [=node navigable=]'s [=navigable/traversable navigable=] is a [=fenced navigable
-      container/fenced navigable=], then set |result|'s [=IP address space=] to [=IP address
-      space/public|public=].
-
-      Otherwise, set |result|'s [=IP address space=] to <var ignore>response</var>'s
-      [=response/IP address space=].
-</div>
-
-<div algorithm=pna-clone-policy>
-  Modify the [=Integration with HTML=] section. Rewrite step 2 to read:
+<div algorithm=pna-html-clone-policy>
+  Modify the [[PRIVATE-NETWORK-ACCESS#integration-html]] section. Rewrite step 2 to read:
 
   2. Modify the definition of [=clone a policy container=] to read:
 
@@ -2372,6 +2370,21 @@ local network access spec to have subresources be subject to those checks.
         public|public=].
 
         Otherwise, set |clone|’s [=IP address space=] to |policyContainer|’s [=IP address space=].
+</div>
+
+<div algorithm=pna-html-response-policy>
+  Modify the [[PRIVATE-NETWORK-ACCESS#integration-html]] section. Rewrite step 3 to read:
+
+  3. An additional step is added to the [=create a policy container from a fetch response=]
+    algorithm:
+
+    1. If |environment| is not null and |environment|'s [=environment/target browsing context=]'s
+       [=browsing context/active document=]'s [=node navigable=]'s [=navigable/traversable
+       navigable=] is a [=fenced navigable container/fenced navigable=], then set |result|'s [=IP
+       address space=] to [=IP address space/public=].
+
+       Otherwise, set |result|'s [=IP address space=] to <var ignore>response</var>'s
+       [=response/IP address space=].
 </div>
 
 <div algorithm=pna-determine-params>

--- a/spec.bs
+++ b/spec.bs
@@ -35,6 +35,7 @@ spec: html; urlPrefix: https://html.spec.whatwg.org/multipage/
     urlPrefix: browsers.html
       text: check a navigation response's adherence to its embedder policy; url: check-a-navigation-response's-adherence-to-its-embedder-policy
       text: queue a cross-origin embedder policy inheritance violation; url: queue-a-cross-origin-embedder-policy-inheritance-violation
+      text: create a policy container from a fetch response; url: creating-a-policy-container-from-a-fetch-response
     urlPrefix: dom.html
       text: categories; url: concept-element-categories
       text: contexts in which this element can be used; url: concept-element-contexts
@@ -60,6 +61,7 @@ spec: html; urlPrefix: https://html.spec.whatwg.org/multipage/
       text: initialize the navigable; url: initialize-the-navigable
       text: node navigable; url: node-navigable
       text: system visibility state; url: system-visibility-state
+      text: active document; url: active-document
       for: navigable
         text: active session history entry; url: nav-active-history-entry
         text: current session history entry; url: nav-current-history-entry
@@ -89,6 +91,8 @@ spec: html; urlPrefix: https://html.spec.whatwg.org/multipage/
     urlPrefix: nav-history-apis.html
       for: Window
         text: navigable; url: window-navigable
+    urlPrefix: webappapis.html
+      text: target browsing context; url:concept-environment-target-browsing-context
 spec: fetch; urlPrefix: https://fetch.spec.whatwg.org/
   type: dfn
     text: queue a cross-origin embedder policy CORP violation report; url: queue-a-cross-origin-embedder-policy-corp-violation-report
@@ -97,6 +101,13 @@ spec: RFC8941; urlPrefix: https://www.rfc-editor.org/rfc/rfc8941.html
     text: structured header; url: #section-1
     for: structured header
       text: token; url: name-tokens
+spec: LNA; urlPrefix: https://wicg.github.io/local-network-access/
+  type: dfn
+    text: Integration with HTML; url: integration-html
+    text: IP address space; url: policy-container-ip-address-space
+    for: response
+      text: IP address space; url: response-ip-address-space
+    text: ip-address-space-public; url: ip-address-space-public
 </pre>
 
 <style>
@@ -880,3 +891,20 @@ specification adds another value for fenced frames:
 
 : "`fencedframe`"
 :: This [=navigable=] is displaying a <{fencedframe}>'s content
+
+<h3 id=local-network-access-monkeypatch>Local Network Access</h3>
+
+<div algorithm=pna-html-changes>
+  Modify the [=Integration with HTML=] section. Rewrite step 3 to read:
+
+  3. An additional step is added to the [=create a policy container from a fetch response=]
+    algorithm:
+
+    1. If |environment| is not null, |environment|'s [=target browsing context=] is not null, and
+      |environment|'s [=target browsing context=]'s [=active document=]'s [=node navigable=]'s
+      [=navigable/traversable navigable=] is a [=fenced navigable container/fenced navigable=], then
+      set |result|'s [=IP address space=] to [=ip-address-space-public|public=].
+
+      Otherwise, set |result|'s [=IP address space=] to <var ignore>response</var>'s
+      [=response/IP address space=].
+</div>

--- a/spec.bs
+++ b/spec.bs
@@ -2373,7 +2373,7 @@ achieve the outcomes described in the above explanatory content.
   /fenced-frame/permission-notification.https.html
 </wpt>
 
-<h3 id=private-network-access-monkeypatch>Private network access</h3>
+<h3 id=private-network-access-monkeypatch>Private Network Access</h3>
 
 [[Private-Network-Access]] is a security feature that allows you to control which web applications
 on can make [=local network requests=]. On creation, <{iframe}>s inherit their policy container from
@@ -2393,8 +2393,8 @@ causes [=subresource requests=] to not do private network access checks. This se
 
     An additional step is added to the algorithm:
 
-      1. If |fenced| is set to true, then set |clone|’s [=IP address space=] to [=IP address space/
-        public|public=].
+      1. If |fenced| is set to true, then set |clone|’s [=IP address space=] to [=IP address
+         space/public=].
 
         Otherwise, set |clone|’s [=IP address space=] to |policyContainer|’s [=IP address space=].
 </div>

--- a/spec.bs
+++ b/spec.bs
@@ -2377,7 +2377,7 @@ achieve the outcomes described in the above explanatory content.
 
 [[Private-Network-Access]] is a security feature that regulates when and how [=local network
 requests=] can be made. On [[HTML#creating-browsing-contexts|creation]], <{iframe}>s inherit their
-[=Document/policy container=] from their [=navigable container=]'s [=node document=], while
+[=Document/policy container=] from their [=navigable container=]'s [=Node/node document=], while
 <{fencedframe}>s do not. While this prevents information from leaking into a <{fencedframe}> from
 its embedder, it also results in a [=Document/policy container=] for {{Document}}s inside of a
 <{fencedframe}> being created that causes [=subresource requests=] to not do private network access

--- a/spec.bs
+++ b/spec.bs
@@ -200,7 +200,6 @@ spec: fetch; urlPrefix: https://fetch.spec.whatwg.org/
   type: dfn
     text: queue a cross-origin embedder policy CORP violation report; url: queue-a-cross-origin-embedder-policy-corp-violation-report
     text: should request be blocked due to a bad port; url: block-bad-port
-    text: is local; url: is-local
 spec: mixed-content; urlPrefix: https://w3c.github.io/webappsec-mixed-content/
   type: dfn
     text: should fetching request be blocked as mixed content; url: should-block-fetch
@@ -1343,7 +1342,7 @@ Note: This is because we need to ensure that we do not leak <var ignore>creator<
 document's referrer|referrer=], [=Document/origin=], [=creator base url=], [=Document/policy
 container=], across the fenced frame boundary.
 
-<h3 id=local-policy-container-monkeypatch>Local Requests Policy Container Patch</h3>
+<h3 id=local-policy-container-monkeypatch>Local requests policy container patch</h3>
 
 When making [=local scheme=] requests, <{iframe}>s inherit their [=Document/policy container=] from
 their [=navigable container=]'s [=Node/node document=]. If <{fencedframe}>s were to do the same

--- a/spec.bs
+++ b/spec.bs
@@ -2375,13 +2375,14 @@ achieve the outcomes described in the above explanatory content.
 
 <h3 id=private-network-access-monkeypatch>Private Network Access</h3>
 
-[[Private-Network-Access]] is a security feature that allows you to control which web applications
-on can make [=local network requests=]. On creation, <{iframe}>s inherit their policy container from
-the navigation initiator, while <{fencedframe}>s explicitly do not. While this prevents information
-from leaking into a <{fencedframe}> from its embedder, it also results in a
-[=Document/policy container=] for {{Document}}s inside of a <{fencedframe}> being created that
-causes [=subresource requests=] to not do private network access checks. This section patches the
-[[Private-Network-Access]] specification to have subresources be subject to those checks.
+[[Private-Network-Access]] is a security feature that regulates when and how [=local network
+requests=] can be made. On [[HTML#creating-browsing-contexts|creation]], <{iframe}>s inherit their
+[=Document/policy container=] from their [=navigable container=]'s [=node document=], while
+<{fencedframe}>s do not. While this prevents information from leaking into a <{fencedframe}> from
+its embedder, it also results in a [=Document/policy container=] for {{Document}}s inside of a
+<{fencedframe}> being created that causes [=subresource requests=] to not do private network access
+checks. This section patches the [[Private-Network-Access]] specification to make subresources be
+subject to those checks.
 
 <div algorithm=pna-html-clone-policy>
   Modify the [[PRIVATE-NETWORK-ACCESS#integration-html]] section. Rewrite step 2 to read:

--- a/spec.bs
+++ b/spec.bs
@@ -39,6 +39,7 @@ spec: html; urlPrefix: https://html.spec.whatwg.org/multipage/
     urlPrefix: browsers.html
       text: check a navigation response's adherence to its embedder policy; url: check-a-navigation-response's-adherence-to-its-embedder-policy
       text: queue a cross-origin embedder policy inheritance violation; url: queue-a-cross-origin-embedder-policy-inheritance-violation
+      text: determine navigation params policy container; url: determining-navigation-params-policy-container
     urlPrefix: dom.html
       text: categories; url: concept-element-categories
       text: contexts in which this element can be used; url: concept-element-contexts
@@ -89,6 +90,8 @@ spec: html; urlPrefix: https://html.spec.whatwg.org/multipage/
         text: replace; url: hh-replace
       for: document state
         text: document; url: document-state-document
+      text: history policy container; url: document-state-history-policy-container
+      text: source policy container; url: source-snapshot-params-policy-container
     urlPrefix: interaction.html
       text: activation notification; url: activation-notification
       text: consume user activation; url: consume-user-activation
@@ -2016,13 +2019,13 @@ achieve the outcomes described in the above explanatory content.
   /fenced-frame/permission-notification.https.html
 </wpt>
 
-<h3 id=local-network-access-monkeypatch>Local Network Access</h3>
+<h3 id=private-network-access-monkeypatch>Private network access</h3>
 
-Local network access is a security feature that allows you to control which apps on your device can
+Private network access is a security feature that allows you to control which apps on your device can
 access your local network. On creation, regular iframes inherit their policy container from the
 navigation initiator, while fenced frames explicitly do not. While this prevents information from
 leaking from an embedder to a fenced frame, this results in a policy container being created that
-causes subresource requests to not do local network access checks. This section patches the local
+causes subresource requests to not do private network access checks. This section patches the local
 network access spec to have subresources be subject to those checks.
 
 <div algorithm=pna-html-changes>
@@ -2039,3 +2042,61 @@ network access spec to have subresources be subject to those checks.
       Otherwise, set |result|'s [=IP address space=] to <var ignore>response</var>'s
       [=response/IP address space=].
 </div>
+
+<div algorithm=pna-clone-policy>
+  Modify the [=Integration with HTML=] section. Rewrite step 2 to read:
+
+  2. Modify the definition of [=clone a policy container=] to read:
+
+    To [=clone a policy container=] given a [=policy container=] |policyContainer| and an optional
+    [=boolean=] |fenced| that defaults to false
+
+    An additional step is added to the algorithm:
+
+      1. If |fenced| is set to true, then set |clone|’s [=IP address space=] to [=IP address space/
+        public|public=].
+
+        Otherwise, set |clone|’s [=IP address space=] to |policyContainer|’s [=IP address space=].
+</div>
+
+<div algorithm=pna-determine-params>
+  Modify the definition of the [=determine navigation params policy container=] algorithm to read:
+
+  To determine navigation params policy container given a [=URL=] |responseURL|; four [=policy
+    container=]-or-nulls |historyPolicyContainer|, |initiatorPolicyContainer|,
+    |parentPolicyContainer|, and <var ignore>responsePolicyContainer</var>; and an optional
+    [=boolean=] |fenced| that defaults to false:
+
+  Rewrite step 1.2 to read:
+    
+    2. Return a [=clone a policy container|clone=] of |historyPolicyContainer| with fenced set to
+      |fenced|.
+
+  Rewrite step 2.2 to read:
+
+    2. Return a [=clone a policy container|clone=] of |parentPolicyContainer| with fenced set to
+      |fenced|.
+
+  Rewrite step 3 to read:
+
+    3. If |responseURL| is local and |initiatorPolicyContainer| is not null, then return a clone of
+      |initiatorPolicyContainer| with fenced set to |fenced|.
+</div>
+
+<div algorithm=pna-populate-session-history-entry>
+  Add a step before step 23 of [=create navigation params by fetching=] that says:
+
+  23. Let |fenced| be true if <var ignore>navigable</var> is a [=fenced navigable container/fenced navigable=],
+    false otherwise.
+
+  Rewrite step 23 (now step 24) to read:
+
+  24. Let <var ignore>resultPolicyContainer</var> be the result of [=determining navigation params policy
+    container=] given <var ignore>response</var>'s URL, <var ignore>entry</var>'s [=document
+    state=]'s [=history policy container=], <var ignore>sourceSnapshotParams</var>'s [=source policy
+    container=], null, <var ignore>responsePolicyContainer</var>, and |fenced|.
+</div>
+
+Note: Inheritance also needs to be gated on initial document creation. However, that is already
+handled in the <a href=#creating-browsing-contexts-patch>Modifications to creating browsing
+contexts</a> section.

--- a/spec.bs
+++ b/spec.bs
@@ -2455,6 +2455,6 @@ subject to those checks.
       <var ignore>responsePolicyContainer</var>, and |fenced|.
 </div>
 
-Note: Inheritance also needs to be gated on initial document creation. However, that is already
-handled in the <a href=#creating-browsing-contexts-patch>Modifications to creating browsing
-contexts</a> section.
+Note: <{fencedframe}> [=policy container=] "inheritance" upon initial {{Document}} creation (and its
+corresponding [=policy container/ip address space=]) is handled in the
+[[#creating-browsing-contexts-patch]] section.

--- a/spec.bs
+++ b/spec.bs
@@ -2419,39 +2419,40 @@ subject to those checks.
   Modify the definition of the [=determine navigation params policy container=] algorithm to read:
 
   To determine navigation params policy container given a [=URL=] |responseURL|; four [=policy
-    container=]-or-nulls |historyPolicyContainer|, |initiatorPolicyContainer|,
-    |parentPolicyContainer|, and <var ignore>responsePolicyContainer</var>; and an optional
-    [=boolean=] |fenced| that defaults to false:
+  container=]-or-nulls |historyPolicyContainer|, |initiatorPolicyContainer|,
+  |parentPolicyContainer|, and <var ignore>responsePolicyContainer</var>; and an optional
+  [=boolean=] |fenced| that defaults to false:
 
-  Rewrite step 1.2 to read:
+  Rewrite step 1, substep 2 to read:
     
-    2. Return a [=clone a policy container|clone=] of |historyPolicyContainer| with fenced set to
-      |fenced|.
+    2. Return a [=clone a policy container|clone=] of |historyPolicyContainer| given |fenced|.
 
-  Rewrite step 2.2 to read:
+  Rewrite step 2, substep 2 to read:
 
-    2. Return a [=clone a policy container|clone=] of |parentPolicyContainer| with fenced set to
-      |fenced|.
+    2. Return a [=clone a policy container|clone=] of |parentPolicyContainer| given |fenced|.
 
   Rewrite step 3 to read:
 
-    3. If |responseURL| is local and |initiatorPolicyContainer| is not null, then return a clone of
-      |initiatorPolicyContainer| with fenced set to |fenced|.
+    3. If |responseURL| is local and |initiatorPolicyContainer| is not null, then return a [=clone a
+       policy container|clone=] of |initiatorPolicyContainer| given |fenced|.
 </div>
 
 <div algorithm=pna-populate-session-history-entry>
   Add a step before step 23 of [=create navigation params by fetching=] that says:
 
-  23. Let |fenced| be true if <var ignore>navigable</var> is a [=fenced navigable container/fenced
-    navigable=], false otherwise.
+  23. Let |fenced| be true if |navigable| is a [=fenced navigable container/fenced navigable=],
+      false otherwise.
+
+      Note: This ensures |fenced| is true regardless of whether the initiator {{Document}} is
+      |navigable|'s [=navigable/active document=] or its [=navigable/unfenced parent=].
 
   Rewrite step 23 (now step 24) to read:
 
   24. Let <var ignore>resultPolicyContainer</var> be the result of [=determining navigation params
-    policy container=] given <var ignore>response</var>'s URL, <var ignore>entry</var>'s [=document
-    state=]'s [=document state/history policy container=], <var ignore>sourceSnapshotParams</var>'s
-    [=source snapshot params/source policy container=], null, <var ignore>responsePolicyContainer
-    </var>, and |fenced|.
+      policy container=] given <var ignore>response</var>'s URL, <var ignore>entry</var>'s
+      [=document state=]'s [=document state/history policy container=], <var
+      ignore>sourceSnapshotParams</var>'s [=source snapshot params/source policy container=], null,
+      <var ignore>responsePolicyContainer</var>, and |fenced|.
 </div>
 
 Note: Inheritance also needs to be gated on initial document creation. However, that is already

--- a/spec.bs
+++ b/spec.bs
@@ -2376,13 +2376,11 @@ achieve the outcomes described in the above explanatory content.
 <h3 id=private-network-access-monkeypatch>Private Network Access</h3>
 
 [[Private-Network-Access]] is a security feature that regulates when and how [=local network
-requests=] can be made. On [[HTML#creating-browsing-contexts|creation]], <{iframe}>s inherit their
-[=Document/policy container=] from their [=navigable container=]'s [=Node/node document=], while
-<{fencedframe}>s do not. While this prevents information from leaking into a <{fencedframe}> from
-its embedder, it also results in a [=Document/policy container=] for {{Document}}s inside of a
-<{fencedframe}> being created that causes [=subresource requests=] to not do private network access
-checks. This section patches the [[Private-Network-Access]] specification to make subresources be
-subject to those checks.
+requests=] can be made. When making local requests, <{iframe}>s inherit their [=Document/policy
+container=] from their [=navigable container=]'s [=Node/node document=]. If fenced frames were to
+do the same thing, that would allow information about the initiator's [=IP address space=] to leak
+across a fenced frame boundary. his section patches the [[Private-Network-Access]] specification to
+close that leak.
 
 <div algorithm=pna-html-clone-policy>
   Modify the [[PRIVATE-NETWORK-ACCESS#integration-html]] section. Rewrite step 2 to read:
@@ -2400,40 +2398,18 @@ subject to those checks.
         Otherwise, set |clone|’s [=IP address space=] to |policyContainer|’s [=IP address space=].
 </div>
 
-<div algorithm=pna-html-response-policy>
-  Modify the [[PRIVATE-NETWORK-ACCESS#integration-html]] section. Rewrite step 3 to read:
-
-  3. An additional step is added to the [=create a policy container from a fetch response=]
-    algorithm:
-
-    1. If |environment| is not null and |environment|'s [=environment/target browsing context=]'s
-       [=browsing context/active document=]'s [=node navigable=]'s [=navigable/traversable
-       navigable=] is a [=fenced navigable container/fenced navigable=], then set |result|'s [=IP
-       address space=] to [=IP address space/public=].
-
-       Otherwise, set |result|'s [=IP address space=] to <var ignore>response</var>'s
-       [=response/IP address space=].
-</div>
-
 <div algorithm=pna-determine-params>
   Modify the definition of the [=determine navigation params policy container=] algorithm to read:
 
   To determine navigation params policy container given a [=URL=] |responseURL|; four [=policy
-  container=]-or-nulls |historyPolicyContainer|, |initiatorPolicyContainer|,
-  |parentPolicyContainer|, and <var ignore>responsePolicyContainer</var>; and an optional
+  container=]-or-nulls <var ignore>historyPolicyContainer</var>, |initiatorPolicyContainer|,
+  <var ignore>parentPolicyContainer</var>, and <var ignore>responsePolicyContainer</var>; and an optional
   [=boolean=] |fenced| that defaults to false:
-
-  Rewrite step 1, substep 2 to read:
-    
-    2. Return a [=clone a policy container|clone=] of |historyPolicyContainer| given |fenced|.
-
-  Rewrite step 2, substep 2 to read:
-
-    2. Return a [=clone a policy container|clone=] of |parentPolicyContainer| given |fenced|.
 
   Rewrite step 3 to read:
 
-    3. If |responseURL| is local and |initiatorPolicyContainer| is not null, then return a [=clone a
+    3. If |responseURL| is local, |initiatorPolicyContainer| is not null, and |fenced| is set to
+       false, then return a [=clone a
        policy container|clone=] of |initiatorPolicyContainer| given |fenced|.
 </div>
 

--- a/spec.bs
+++ b/spec.bs
@@ -84,9 +84,6 @@ spec: prerendering-revamped; urlPrefix: https://wicg.github.io/nav-speculation/p
     for: navigable
       text: loading mode; url: #navigable-loading-mode
 
-spec: fetch; urlPrefix: https://fetch.spec.whatwg.org/
-  type: dfn
-    text: queue a cross-origin embedder policy CORP violation report; url: queue-a-cross-origin-embedder-policy-corp-violation-report
 spec: html; urlPrefix: https://html.spec.whatwg.org/multipage/
   type: dfn
     urlPrefix: browsers.html
@@ -197,10 +194,13 @@ spec: html; urlPrefix: https://html.spec.whatwg.org/multipage/
       text: face validation anchor; url: face-validation-anchor
     urlPrefix: webappapis.html
       text: fire a click event; url: fire-a-click-event
+    urlPrefix: urls-and-fetching.html
+      text: about:srcdoc; url: about:srcdoc
 spec: fetch; urlPrefix: https://fetch.spec.whatwg.org/
   type: dfn
     text: queue a cross-origin embedder policy CORP violation report; url: queue-a-cross-origin-embedder-policy-corp-violation-report
     text: should request be blocked due to a bad port; url: block-bad-port
+    text: is local; url: is-local
 spec: mixed-content; urlPrefix: https://w3c.github.io/webappsec-mixed-content/
   type: dfn
     text: should fetching request be blocked as mixed content; url: should-block-fetch
@@ -1345,13 +1345,14 @@ container=], across the fenced frame boundary.
 
 <h3 id=local-policy-container-monkeypatch>Local Requests Policy Container Patch</h3>
 
-When making local requests, <{iframe}>s inherit their [=Document/policy container=] from their
-[=navigable container=]'s [=Node/node document=]. If <{fencedframe}>s were to do the same thing,
-that would allow information about the initiator's [=IP address space=] to leak across a fenced
-frame boundary. This section patches [=Document/policy container=] inheritance to close that leak.
+When making [=local scheme=] requests, <{iframe}>s inherit their [=Document/policy container=] from
+their [=navigable container=]'s [=Node/node document=]. If <{fencedframe}>s were to do the same
+thing, that would allow information about the initiator's [=Document/policy container=] to leak
+across a fenced frame boundary. This section patches [=Document/policy container=] inheritance to
+close that leak.
 
 <div algorithm=local-policy-inheritance-determine-params>
-  Modify the definition of the [=determine navigation params policy container=] algorithm to read:
+  Modify the [=determine navigation params policy container=] algorithm to read:
 
   To determine navigation params policy container given a [=URL=] |responseURL|; four [=policy
   container=]-or-nulls <var ignore>historyPolicyContainer</var>, |initiatorPolicyContainer|,
@@ -1360,8 +1361,11 @@ frame boundary. This section patches [=Document/policy container=] inheritance t
 
   Rewrite step 3 to read:
 
-    3. If |responseURL| is local, |initiatorPolicyContainer| is not null, and |fenced| is set to
+    3. If |responseURL| [=is local=], |initiatorPolicyContainer| is not null, and |fenced| is set to
        false, then return a [=clone a policy container|clone=] of |initiatorPolicyContainer|.
+
+  Note: We do not need to modify the <code>[=about:srcdoc=]</code> case because navigations to
+  <code>[=about:srcdoc=]</code> are not supported in fenced frames.
 </div>
 
 <div algorithm=local-policy-inheritance-populate-session-history-entry>
@@ -1376,13 +1380,13 @@ frame boundary. This section patches [=Document/policy container=] inheritance t
   Rewrite step 23 (now step 24) to read:
 
   24. Let <var ignore>resultPolicyContainer</var> be the result of [=determining navigation params
-      policy container=] given <var ignore>response</var>'s URL, <var ignore>entry</var>'s
-      [=document state=]'s [=document state/history policy container=], <var
-      ignore>sourceSnapshotParams</var>'s [=source snapshot params/source policy container=], null,
-      <var ignore>responsePolicyContainer</var>, and |fenced|.
+      policy container=] given <var ignore>response</var>'s [=response/URL=], <var ignore>
+      entry</var>'s [=document state=]'s [=document state/history policy container=], <var ignore>
+      sourceSnapshotParams</var>'s [=source snapshot params/source policy container=], null, <var
+      ignore>responsePolicyContainer</var>, and |fenced|.
 </div>
 
-Note: <{fencedframe}> [=policy container=] "inheritance" upon initial {{Document}} creation (and its
+Note: <{fencedframe}> [=policy container=] inheritance upon initial {{Document}} creation (and its
 corresponding [=policy container/ip address space=]) is handled in the
 [[#creating-browsing-contexts-patch]] section.
 

--- a/spec.bs
+++ b/spec.bs
@@ -1346,9 +1346,9 @@ container=], across the fenced frame boundary.
 <h3 id=local-policy-container-monkeypatch>Local Requests Policy Container Patch</h3>
 
 When making local requests, <{iframe}>s inherit their [=Document/policy container=] from their
-[=navigable container=]'s [=Node/node document=]. If fenced frames were to do the same thing, that
-would allow information about the initiator's [=IP address space=] to leak across a fenced frame
-boundary. his section patches [=Document/policy container=] inheritance to close that leak.
+[=navigable container=]'s [=Node/node document=]. If <{fencedframe}>s were to do the same thing,
+that would allow information about the initiator's [=IP address space=] to leak across a fenced
+frame boundary. This section patches [=Document/policy container=] inheritance to close that leak.
 
 <div algorithm=local-policy-inheritance-determine-params>
   Modify the definition of the [=determine navigation params policy container=] algorithm to read:

--- a/spec.bs
+++ b/spec.bs
@@ -148,13 +148,9 @@ spec: RFC8941; urlPrefix: https://www.rfc-editor.org/rfc/rfc8941.html
     text: structured header; url: #section-1
     for: structured header
       text: token; url: name-tokens
-spec: LNA; urlPrefix: https://wicg.github.io/local-network-access/
+spec: local-network-access; urlPrefix: https://wicg.github.io/local-network-access/
   type: dfn
     text: Integration with HTML; url: integration-html
-    text: IP address space; url: policy-container-ip-address-space
-    for: response
-      text: IP address space; url: response-ip-address-space
-    text: ip-address-space-public; url: ip-address-space-public
 spec: permissions-policy; urlPrefix: https://w3c.github.io/webappsec-permissions-policy
   type: dfn
     text: ASCII-serialized policy directive; url: serialized-policy-directive
@@ -2033,10 +2029,11 @@ achieve the outcomes described in the above explanatory content.
 <h3 id=local-network-access-monkeypatch>Local Network Access</h3>
 
 Local network access is a security feature that allows you to control which apps on your device can
-access your local network. Regular iframes inherit their policy container from the navigation
-initiator, while fenced frames explicitly do not. This results in a policy container being created
-that causes subresource requests to not do PNA checks. This section patches the PNA spec to have
-subresources be subject to those checks.
+access your local network. On creation, regular iframes inherit their policy container from the
+navigation initiator, while fenced frames explicitly do not. While this prevents information from
+leaking from an embedder to a fenced frame, this results in a policy container being created that
+causes subresource requests to not do local network access checks. This section patches the local
+network access spec to have subresources be subject to those checks.
 
 <div algorithm=pna-html-changes>
   Modify the [=Integration with HTML=] section. Rewrite step 3 to read:
@@ -2047,7 +2044,7 @@ subresources be subject to those checks.
     1. If |environment| is not null, |environment|'s [=target browsing context=] is not null, and
       |environment|'s [=target browsing context=]'s [=active document=]'s [=node navigable=]'s
       [=navigable/traversable navigable=] is a [=fenced navigable container/fenced navigable=], then
-      set |result|'s [=IP address space=] to [=ip-address-space-public|public=].
+      set |result|'s [=IP address space=] to [=IP address space/public|public=].
 
       Otherwise, set |result|'s [=IP address space=] to <var ignore>response</var>'s
       [=response/IP address space=].

--- a/spec.bs
+++ b/spec.bs
@@ -894,6 +894,12 @@ specification adds another value for fenced frames:
 
 <h3 id=local-network-access-monkeypatch>Local Network Access</h3>
 
+Local network access is a security feature that allows you to control which apps on your device can
+access your local network. Regular iframes inherit their policy container from the navigation
+initiator, while fenced frames explicitly do not. This results in a policy container being created
+that causes subresource requests to not do PNA checks. This section patches the PNA spec to have
+subresources be subject to those checks.
+
 <div algorithm=pna-html-changes>
   Modify the [=Integration with HTML=] section. Rewrite step 3 to read:
 

--- a/spec.bs
+++ b/spec.bs
@@ -22,22 +22,6 @@ WPT Display: open
 
 <pre class="link-defaults">
 </pre>
-<pre class="biblio">
-{
-  "private-network-access": {
-    "authors": [
-      "Titouan Rigoudy"
-    ],
-    "href": "https://wicg.github.io/private-network-access",
-    "title": "Private Network Access",
-    "status": "CG-DRAFT",
-    "publisher": "WICG",
-    "deliveredBy": [
-      "https://wicg.io/"
-    ]
-  }
-}
-</pre>
 <pre class="anchors">
 urlPrefix: https://www.ietf.org/rfc/rfc4122.txt
   type: dfn; text: urn uuid
@@ -1279,6 +1263,49 @@ Note: This is because we need to ensure that we do not leak <var ignore>creator<
 document's referrer|referrer=], [=Document/origin=], [=creator base url=], [=Document/policy
 container=], across the fenced frame boundary.
 
+<h3 id=local-policy-container-monkeypatch>Local Requests Policy Container Patch</h3>
+
+When making local requests, <{iframe}>s inherit their [=Document/policy container=] from their
+[=navigable container=]'s [=Node/node document=]. If fenced frames were to do the same thing, that
+would allow information about the initiator's [=IP address space=] to leak across a fenced frame
+boundary. his section patches [=Document/policy container=] inheritance to close that leak.
+
+<div algorithm=local-policy-inheritance-determine-params>
+  Modify the definition of the [=determine navigation params policy container=] algorithm to read:
+
+  To determine navigation params policy container given a [=URL=] |responseURL|; four [=policy
+  container=]-or-nulls <var ignore>historyPolicyContainer</var>, |initiatorPolicyContainer|,
+  <var ignore>parentPolicyContainer</var>, and <var ignore>responsePolicyContainer</var>; and an
+  optional [=boolean=] |fenced| that defaults to false:
+
+  Rewrite step 3 to read:
+
+    3. If |responseURL| is local, |initiatorPolicyContainer| is not null, and |fenced| is set to
+       false, then return a [=clone a policy container|clone=] of |initiatorPolicyContainer|.
+</div>
+
+<div algorithm=local-policy-inheritance-populate-session-history-entry>
+  Add a step before step 23 of [=create navigation params by fetching=] that says:
+
+  23. Let |fenced| be true if |navigable| is a [=fenced navigable container/fenced navigable=],
+      false otherwise.
+
+      Note: This ensures |fenced| is true regardless of whether the initiator {{Document}} is
+      |navigable|'s [=navigable/active document=] or its [=navigable/unfenced parent=].
+
+  Rewrite step 23 (now step 24) to read:
+
+  24. Let <var ignore>resultPolicyContainer</var> be the result of [=determining navigation params
+      policy container=] given <var ignore>response</var>'s URL, <var ignore>entry</var>'s
+      [=document state=]'s [=document state/history policy container=], <var
+      ignore>sourceSnapshotParams</var>'s [=source snapshot params/source policy container=], null,
+      <var ignore>responsePolicyContainer</var>, and |fenced|.
+</div>
+
+Note: <{fencedframe}> [=policy container=] "inheritance" upon initial {{Document}} creation (and its
+corresponding [=policy container/ip address space=]) is handled in the
+[[#creating-browsing-contexts-patch]] section.
+
 <h3 id=nested-traversables>Nested traversables</h3>
 
 <h4 id=nested-traversables-intro>Introduction</h4>
@@ -2372,65 +2399,3 @@ achieve the outcomes described in the above explanatory content.
   /fenced-frame/permission-geolocation.https.html
   /fenced-frame/permission-notification.https.html
 </wpt>
-
-<h3 id=private-network-access-monkeypatch>Private Network Access</h3>
-
-[[Private-Network-Access]] is a security feature that regulates when and how [=local network
-requests=] can be made. When making local requests, <{iframe}>s inherit their [=Document/policy
-container=] from their [=navigable container=]'s [=Node/node document=]. If fenced frames were to
-do the same thing, that would allow information about the initiator's [=IP address space=] to leak
-across a fenced frame boundary. his section patches the [[Private-Network-Access]] specification to
-close that leak.
-
-<div algorithm=pna-html-clone-policy>
-  Modify the [[PRIVATE-NETWORK-ACCESS#integration-html]] section. Rewrite step 2 to read:
-
-  2. Modify the definition of [=clone a policy container=] to read:
-
-    To [=clone a policy container=] given a [=policy container=] |policyContainer| and an optional
-    [=boolean=] |fenced| that defaults to false
-
-    An additional step is added to the algorithm:
-
-      1. If |fenced| is set to true, then set |clone|’s [=IP address space=] to [=IP address
-         space/public=].
-
-        Otherwise, set |clone|’s [=IP address space=] to |policyContainer|’s [=IP address space=].
-</div>
-
-<div algorithm=pna-determine-params>
-  Modify the definition of the [=determine navigation params policy container=] algorithm to read:
-
-  To determine navigation params policy container given a [=URL=] |responseURL|; four [=policy
-  container=]-or-nulls <var ignore>historyPolicyContainer</var>, |initiatorPolicyContainer|,
-  <var ignore>parentPolicyContainer</var>, and <var ignore>responsePolicyContainer</var>; and an optional
-  [=boolean=] |fenced| that defaults to false:
-
-  Rewrite step 3 to read:
-
-    3. If |responseURL| is local, |initiatorPolicyContainer| is not null, and |fenced| is set to
-       false, then return a [=clone a
-       policy container|clone=] of |initiatorPolicyContainer| given |fenced|.
-</div>
-
-<div algorithm=pna-populate-session-history-entry>
-  Add a step before step 23 of [=create navigation params by fetching=] that says:
-
-  23. Let |fenced| be true if |navigable| is a [=fenced navigable container/fenced navigable=],
-      false otherwise.
-
-      Note: This ensures |fenced| is true regardless of whether the initiator {{Document}} is
-      |navigable|'s [=navigable/active document=] or its [=navigable/unfenced parent=].
-
-  Rewrite step 23 (now step 24) to read:
-
-  24. Let <var ignore>resultPolicyContainer</var> be the result of [=determining navigation params
-      policy container=] given <var ignore>response</var>'s URL, <var ignore>entry</var>'s
-      [=document state=]'s [=document state/history policy container=], <var
-      ignore>sourceSnapshotParams</var>'s [=source snapshot params/source policy container=], null,
-      <var ignore>responsePolicyContainer</var>, and |fenced|.
-</div>
-
-Note: <{fencedframe}> [=policy container=] "inheritance" upon initial {{Document}} creation (and its
-corresponding [=policy container/ip address space=]) is handled in the
-[[#creating-browsing-contexts-patch]] section.

--- a/spec.bs
+++ b/spec.bs
@@ -95,12 +95,12 @@ spec: html; urlPrefix: https://html.spec.whatwg.org/multipage/
         text: replace; url: hh-replace
       for: document state
         text: document; url: document-state-document
+        text: history policy container; url: document-state-history-policy-container
       text: checking if unloading is user-canceled
-      text: history policy container; url: document-state-history-policy-container
-      text: source policy container; url: source-snapshot-params-policy-container
       text: source snapshot params
       for: source snapshot params
         text: fetch client; url: source-snapshot-params-client
+        text: source policy container; url: source-snapshot-params-policy-container
     urlPrefix: interaction.html
       text: activation notification; url: activation-notification
       text: consume user activation; url: consume-user-activation
@@ -2335,12 +2335,12 @@ achieve the outcomes described in the above explanatory content.
 
 <h3 id=private-network-access-monkeypatch>Private network access</h3>
 
-Private network access is a security feature that allows you to control which apps on your device can
-access your local network. On creation, regular iframes inherit their policy container from the
-navigation initiator, while fenced frames explicitly do not. While this prevents information from
-leaking from an embedder to a fenced frame, this results in a policy container being created that
-causes subresource requests to not do private network access checks. This section patches the local
-network access spec to have subresources be subject to those checks.
+Private network access is a security feature that allows you to control which apps on your device
+can access your local network. On creation, regular iframes can inherit their policy container from
+the navigation initiator, while fenced frames explicitly do not. While this prevents information
+from leaking from an embedder to a fenced frame, this results in a policy container being created
+that causes subresource requests to not do private network access checks. This section patches the
+local network access spec to have subresources be subject to those checks.
 
 <div algorithm=pna-html-changes>
   Modify the [=Integration with HTML=] section. Rewrite step 3 to read:
@@ -2348,10 +2348,11 @@ network access spec to have subresources be subject to those checks.
   3. An additional step is added to the [=create a policy container from a fetch response=]
     algorithm:
 
-    1. If |environment| is not null, |environment|'s [=environment/target browsing context=] is not null, and
-      |environment|'s [=environment/target browsing context=]'s [=browsing context/active document=]'s [=node
-      navigable=]'s [=navigable/traversable navigable=] is a [=fenced navigable container/fenced
-      navigable=], then set |result|'s [=IP address space=] to [=IP address space/public|public=].
+    1. If |environment| is not null, |environment|'s [=environment/target browsing context=] is not
+      null, and |environment|'s [=environment/target browsing context=]'s [=browsing context/active
+      document=]'s [=node navigable=]'s [=navigable/traversable navigable=] is a [=fenced navigable
+      container/fenced navigable=], then set |result|'s [=IP address space=] to [=IP address
+      space/public|public=].
 
       Otherwise, set |result|'s [=IP address space=] to <var ignore>response</var>'s
       [=response/IP address space=].
@@ -2400,15 +2401,16 @@ network access spec to have subresources be subject to those checks.
 <div algorithm=pna-populate-session-history-entry>
   Add a step before step 23 of [=create navigation params by fetching=] that says:
 
-  23. Let |fenced| be true if <var ignore>navigable</var> is a [=fenced navigable container/fenced navigable=],
-    false otherwise.
+  23. Let |fenced| be true if <var ignore>navigable</var> is a [=fenced navigable container/fenced
+    navigable=], false otherwise.
 
   Rewrite step 23 (now step 24) to read:
 
-  24. Let <var ignore>resultPolicyContainer</var> be the result of [=determining navigation params policy
-    container=] given <var ignore>response</var>'s URL, <var ignore>entry</var>'s [=document
-    state=]'s [=history policy container=], <var ignore>sourceSnapshotParams</var>'s [=source policy
-    container=], null, <var ignore>responsePolicyContainer</var>, and |fenced|.
+  24. Let <var ignore>resultPolicyContainer</var> be the result of [=determining navigation params
+    policy container=] given <var ignore>response</var>'s URL, <var ignore>entry</var>'s [=document
+    state=]'s [=document state/history policy container=], <var ignore>sourceSnapshotParams</var>'s
+    [=source snapshot params/source policy container=], null, <var ignore>responsePolicyContainer
+    </var>, and |fenced|.
 </div>
 
 Note: Inheritance also needs to be gated on initial document creation. However, that is already

--- a/spec.bs
+++ b/spec.bs
@@ -39,7 +39,6 @@ spec: html; urlPrefix: https://html.spec.whatwg.org/multipage/
     urlPrefix: browsers.html
       text: check a navigation response's adherence to its embedder policy; url: check-a-navigation-response's-adherence-to-its-embedder-policy
       text: queue a cross-origin embedder policy inheritance violation; url: queue-a-cross-origin-embedder-policy-inheritance-violation
-      text: create a policy container from a fetch response; url: creating-a-policy-container-from-a-fetch-response
     urlPrefix: dom.html
       text: categories; url: concept-element-categories
       text: contexts in which this element can be used; url: concept-element-contexts
@@ -65,7 +64,6 @@ spec: html; urlPrefix: https://html.spec.whatwg.org/multipage/
       text: initialize the navigable; url: initialize-the-navigable
       text: node navigable; url: node-navigable
       text: system visibility state; url: system-visibility-state
-      text: active document; url: active-document
       for: navigable
         text: active session history entry; url: nav-active-history-entry
         text: current session history entry; url: nav-current-history-entry
@@ -2042,9 +2040,9 @@ network access spec to have subresources be subject to those checks.
     algorithm:
 
     1. If |environment| is not null, |environment|'s [=target browsing context=] is not null, and
-      |environment|'s [=target browsing context=]'s [=active document=]'s [=node navigable=]'s
-      [=navigable/traversable navigable=] is a [=fenced navigable container/fenced navigable=], then
-      set |result|'s [=IP address space=] to [=IP address space/public|public=].
+      |environment|'s [=target browsing context=]'s [=browsing context/active document=]'s [=node
+      navigable=]'s [=navigable/traversable navigable=] is a [=fenced navigable container/fenced
+      navigable=], then set |result|'s [=IP address space=] to [=IP address space/public|public=].
 
       Otherwise, set |result|'s [=IP address space=] to <var ignore>response</var>'s
       [=response/IP address space=].

--- a/spec.bs
+++ b/spec.bs
@@ -1342,13 +1342,13 @@ Note: This is because we need to ensure that we do not leak <var ignore>creator<
 document's referrer|referrer=], [=Document/origin=], [=creator base url=], [=Document/policy
 container=], across the fenced frame boundary.
 
-<h3 id=local-policy-container-monkeypatch>Local requests policy container patch</h3>
+<h3 id=local-scheme-policy-container-monkeypatch>Local scheme requests policy container patch</h3>
 
-When making [=local scheme=] requests, <{iframe}>s inherit their [=Document/policy container=] from
-their [=navigable container=]'s [=Node/node document=]. If <{fencedframe}>s were to do the same
-thing, that would allow information about the initiator's [=Document/policy container=] to leak
-across a fenced frame boundary. This section patches [=Document/policy container=] inheritance to
-close that leak.
+When making a [=navigation request=] to a [=is local|local=] [=URL=], <{iframe}>s clone their
+[=Document/policy container=] from the [=Document/policy container=] of the {{Document}} initiating
+the [=navigation request=]. If <{fencedframe}>s were to do the same thing, that would allow
+information about the initiator's [=Document/policy container=] to leak across a fenced frame
+boundary. This section patches [=Document/policy container=] inheritance to close that leak.
 
 <div algorithm=local-policy-inheritance-determine-params>
   Modify the [=determine navigation params policy container=] algorithm to read:
@@ -1385,9 +1385,8 @@ close that leak.
       ignore>responsePolicyContainer</var>, and |fenced|.
 </div>
 
-Note: <{fencedframe}> [=policy container=] inheritance upon initial {{Document}} creation (and its
-corresponding [=policy container/ip address space=]) is handled in the
-[[#creating-browsing-contexts-patch]] section.
+Note: <{fencedframe}> [=policy container=] inheritance upon initial {{Document}} creation is handled
+in the [[#creating-browsing-contexts-patch]] section.
 
 <h3 id=nested-traversables>Nested traversables</h3>
 

--- a/spec.bs
+++ b/spec.bs
@@ -1342,29 +1342,25 @@ Note: This is because we need to ensure that we do not leak <var ignore>creator<
 document's referrer|referrer=], [=Document/origin=], [=creator base url=], [=Document/policy
 container=], across the fenced frame boundary.
 
-<h3 id=local-scheme-policy-container-monkeypatch>Local scheme requests policy container patch</h3>
+<h3 id=local-scheme-policy-container-inheritance>Policy container inheritance</h3>
 
 When making a [=navigation request=] to a [=is local|local=] [=URL=], <{iframe}>s clone their
-[=Document/policy container=] from the [=Document/policy container=] of the {{Document}} initiating
-the [=navigation request=]. If <{fencedframe}>s were to do the same thing, that would allow
-information about the initiator's [=Document/policy container=] to leak across a fenced frame
-boundary. This section patches [=Document/policy container=] inheritance to close that leak.
+[=Document/policy container=] from the [=navigation request=]'s *initiator* {{Document}}. If
+<{fencedframe}>s were to do the same thing, that would allow information about the initiator's
+[=Document/policy container=] to leak across a fenced frame boundary. This section patches
+[=Document/policy container=] inheritance to close that leak.
 
 <div algorithm=local-policy-inheritance-determine-params>
-  Modify the [=determine navigation params policy container=] algorithm to read:
-
-  To determine navigation params policy container given a [=URL=] |responseURL|; four [=policy
-  container=]-or-nulls <var ignore>historyPolicyContainer</var>, |initiatorPolicyContainer|,
-  <var ignore>parentPolicyContainer</var>, and <var ignore>responsePolicyContainer</var>; and an
-  optional [=boolean=] |fenced| that defaults to false:
+  Modify the [=determine navigation params policy container=] algorithm to have a new optional
+  [=boolean=] parameter |fenced| that defaults to false.
 
   Rewrite step 3 to read:
 
-    3. If |responseURL| [=is local=], |initiatorPolicyContainer| is not null, and |fenced| is set to
-       false, then return a [=clone a policy container|clone=] of |initiatorPolicyContainer|.
+    3. If |responseURL| [=is local=], |initiatorPolicyContainer| is not null, and |fenced| false,
+       then return a [=clone a policy container|clone=] of |initiatorPolicyContainer|.
 
-  Note: We do not need to modify the <code>[=about:srcdoc=]</code> case because navigations to
-  <code>[=about:srcdoc=]</code> are not supported in fenced frames.
+  Note: We do not need to modify the case where |responseURL| is <code>[=about:srcdoc=]</code>,
+  because navigations to <code>[=about:srcdoc=]</code> are not supported in fenced frames.
 </div>
 
 <div algorithm=local-policy-inheritance-populate-session-history-entry>

--- a/spec.bs
+++ b/spec.bs
@@ -117,10 +117,6 @@ spec: html; urlPrefix: https://html.spec.whatwg.org/multipage/
     urlPrefix: document-sequences.html
       for: browsing context
         text: active document; url: active-document
-spec: fetch; urlPrefix: https://fetch.spec.whatwg.org/
-  type: dfn
-    text: queue a cross-origin embedder policy CORP violation report; url: queue-a-cross-origin-embedder-policy-corp-violation-report
-    text: should request be blocked due to a bad port; url: block-bad-port
 spec: mixed-content; urlPrefix: https://w3c.github.io/webappsec-mixed-content/
   type: dfn
     text: should fetching request be blocked as mixed content; url: should-block-fetch
@@ -137,10 +133,6 @@ spec: CSP; urlPrefix: https://w3c.github.io/webappsec-csp/
       text: face validation anchor; url: face-validation-anchor
     urlPrefix: webappapis.html
       text: fire a click event; url: fire-a-click-event
-      text: target browsing context; url:concept-environment-target-browsing-context
-spec: fetch; urlPrefix: https://fetch.spec.whatwg.org/
-  type: dfn
-    text: queue a cross-origin embedder policy CORP violation report; url: queue-a-cross-origin-embedder-policy-corp-violation-report
 spec: RFC8941; urlPrefix: https://www.rfc-editor.org/rfc/rfc8941.html
   type: dfn
     text: structured header; url: #section-1
@@ -2039,8 +2031,8 @@ network access spec to have subresources be subject to those checks.
   3. An additional step is added to the [=create a policy container from a fetch response=]
     algorithm:
 
-    1. If |environment| is not null, |environment|'s [=target browsing context=] is not null, and
-      |environment|'s [=target browsing context=]'s [=browsing context/active document=]'s [=node
+    1. If |environment| is not null, |environment|'s [=environment/target browsing context=] is not null, and
+      |environment|'s [=environment/target browsing context=]'s [=browsing context/active document=]'s [=node
       navigable=]'s [=navigable/traversable navigable=] is a [=fenced navigable container/fenced
       navigable=], then set |result|'s [=IP address space=] to [=IP address space/public|public=].
 


### PR DESCRIPTION
When navigating to a URL with a local scheme (URLs like about:blank), iframes clone their policy container from the policy container of the navigation's initiating document. We don't want fenced frames to be able to do that, since that will tell the fenced frame information about a policy container that lives past a fenced frame boundary. This PR adds a patch to stop that inheritance from happening.

(Implementation detail) Note that with the Chromium's MPArch implementation of fenced frames, we get that behavior for free because the initiator frame token is not passed in to the policy container builder during the navigation request. However, we want to make sure that any other implementations also have this behavior, which is why this patch is needed.

The main algorithm that is patched is [determine navigation params policy container](https://html.spec.whatwg.org/multipage/browsers.html#determining-navigation-params-policy-container). It now takes a new "fenced" parameter that prevents cloning the initiator policy container if set to true. There are 3 places where this function is called:

- [Within the beginning navigation algorithm](https://html.spec.whatwg.org/multipage/browsing-the-web.html#beginning-navigation:determining-navigation-params-policy-container), which does not need a patch because the part of the algorithm where this is hit only applies to object and embed elements (it will never hit for fenced frames).
- [Within “create navigation params from a srcdoc resource”](https://html.spec.whatwg.org/multipage/browsing-the-web.html#populating-a-session-history-entry:determining-navigation-params-policy-container), which does not need a patch because srcdoc is not supported in fenced frames.
- [Within create navigation params by fetching](https://html.spec.whatwg.org/multipage/browsing-the-web.html#populating-a-session-history-entry:determining-navigation-params-policy-container-2), which **does** need a patch because this is the path that is taken when fetch is called to navigate a fenced frame.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/WICG/fenced-frame/pull/73.html" title="Last updated on Jun 22, 2023, 2:08 PM UTC (5b23c1d)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/fenced-frame/73/fb89d8c...5b23c1d.html" title="Last updated on Jun 22, 2023, 2:08 PM UTC (5b23c1d)">Diff</a>