### PR TITLE
Export fencedframe dfn

### DIFF
--- a/spec.bs
+++ b/spec.bs
@@ -183,7 +183,7 @@ dl, dd {
 
 <script src="https://resources.whatwg.org/file-issue.js" async></script>
 
-<h2 id=the-fencedframe-element>The <dfn element>fencedframe</dfn> element</h2>
+<h2 id=the-fencedframe-element>The <dfn element export>fencedframe</dfn> element</h2>
 
 <dl class="element">
  <dt>[=Categories=]:</dt>


### PR DESCRIPTION
Would be useful in https://github.com/WICG/turtledove/pull/539 (and probably other places eventually).


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/miketaylr/fenced-frame/pull/75.html" title="Last updated on Apr 14, 2023, 12:26 AM UTC (edfda45)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/fenced-frame/75/4b6b5ec...miketaylr:edfda45.html" title="Last updated on Apr 14, 2023, 12:26 AM UTC (edfda45)">Diff</a>