### PR TITLE
Introduce navigable's config instance

### DIFF
--- a/spec.bs
+++ b/spec.bs
@@ -706,6 +706,18 @@ A <dfn export>fenced frame config instance</dfn> is a struct with the following 
     :: |config|'s [=fenced frame config/embedder shared storage context=]
 </div>
 
+Each [=navigable=] has a <dfn for=navigable>fenced frame config instance</dfn>, which is a [=fenced
+frame config instance=] or null, initially null.
+
+Advisement: This [=navigable/fenced frame config instance=] should really exist on [=traversable
+navigable=], specifically a [=fenced navigable container/fenced navigable=], however until
+third-party cookies are <a
+href=https://w3ctag.github.io/web-without-3p-cookies/#introduction>deprecated</a>, this
+specification supports many of the <{fencedframe}> constructs on the <{iframe}> element. This
+requires that for the short term, a normal [=navigable container/content navigable=] be able to load
+a [=fenced frame config=], and therefore have access to the navigation's corresponding [=fenced
+frame config instance=].
+
 <h4 id=fenced-frame-config-interface>The {{FencedFrameConfig}} interface</h4>
 
 One major input to the <{fencedframe}> element is the {{FencedFrameConfig}} interface, which
@@ -829,10 +841,7 @@ Several APIs specific to fenced frames are defined on the {{Fence}} interface.
   The <dfn method for=Fence>reportEvent(|event|)</dfn> method steps are:
 
   1. Let |instance| be [=this=]'s [=relevant global object=]'s [=associated Document=]'s [=node
-     navigable=]'s [=navigable/traversable navigable=]'s [=fenced frame config instance=].
-
-     <span class=XXX>This and the below references should point to an actual member on [=traversable
-     navigable=], not just the type.</span>
+     navigable=]'s [=navigable/traversable navigable=]'s [=navigable/fenced frame config instance=].
 
   1. If |instance| is null, then return.
 
@@ -854,7 +863,7 @@ Several APIs specific to fenced frames are defined on the {{Fence}} interface.
   method steps are:
 
   1. Let |instance| be [=this=]'s [=relevant global object=]'s [=associated Document=]'s [=node
-     navigable=]'s [=navigable/traversable navigable=]'s [=fenced frame config instance=].
+     navigable=]'s [=navigable/traversable navigable=]'s [=navigable/fenced frame config instance=].
 
   1. If |instance| is null, then return.
 
@@ -872,7 +881,7 @@ Several APIs specific to fenced frames are defined on the {{Fence}} interface.
   The <dfn method for=Fence>getNestedConfigs()</dfn> method steps are:
 
   1. Let |instance| be [=this=]'s [=relevant global object=]'s [=associated Document=]'s [=node
-     navigable=]'s [=navigable/traversable navigable=]'s [=fenced frame config instance=].
+     navigable=]'s [=navigable/traversable navigable=]'s [=navigable/fenced frame config instance=].
 
   1. If |instance| is null, then return.
 

--- a/spec.bs
+++ b/spec.bs
@@ -941,8 +941,8 @@ Each {{Window}} object has an associated <dfn for=Window>fence</dfn>, which is a
 
 <div algorithm>
   The <dfn attribute for=Window>fence</dfn> getter steps are:
-    1. If [=this=]'s [=Window/navigable=]'s [=fenced frame config instance=] is not null, then
-       return [=this=]'s [=Window/fence=].
+    1. If [=this=]'s [=Window/navigable=]'s [=navigable/fenced frame config instance=] is not null,
+       then return [=this=]'s [=Window/fence=].
 
     1. Return null.
 </div>


### PR DESCRIPTION
I think this PR makes things better and more explicit, but I believe things are still broken even after this. A few questions/points:

 - In the `Fence` methods, should it ever be possible for `instance` to be null, as we check for in step 2? I think the `instance` that we check when retrieving the `Fence` object in the first place (https://wicg.github.io/fenced-frame/#dom-window-fence > Step 2) should be a sufficient gate, such that we don't have to check for _instance_ anymore inside the methods, right? The way I envision the ideal world here, is that because we have to support URN iframes, we make the "instance" retriever in both the `window.fence` getter and the `fence.*` methods both traverse upwards until they find a navigable with a non-null _instance_ and both reference that instance. Does that sound right?


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/WICG/fenced-frame/pull/80.html" title="Last updated on Apr 25, 2023, 1:24 PM UTC (630d476)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/fenced-frame/80/ff89560...630d476.html" title="Last updated on Apr 25, 2023, 1:24 PM UTC (630d476)">Diff</a>