### PR TITLE
[Spec] Fix broken link

### DIFF
--- a/spec.bs
+++ b/spec.bs
@@ -11,7 +11,7 @@ Boilerplate: omit conformance, omit feedback-header
 Editor: Dominic Farolino, Google https://www.google.com/, domfarolino@gmail.com, https://domfarolino.com
 Abstract: The fenced frame enforces a boundary between the embedding page and the cross-site embedded document such that user data visible to the two sites is not able to be joined together.
 !Participate: <a href="https://github.com/WICG/fenced-frame">GitHub WICG/fenced-frame</a> (<a href="https://github.com/WICG/fenced-frame/issues/new">new issue</a>, <a href="https://github.com/WICG/fenced-frame/issues?state=open">open issues</a>)
-!Commits: <a href="https://github.com/WICG/fenced-frame/commits/main/spec.bs">GitHub spec.bs commits</a>
+!Commits: <a href="https://github.com/WICG/fenced-frame/commits/master/spec.bs">GitHub spec.bs commits</a>
 Complain About: accidental-2119 yes, missing-example-ids yes
 Indent: 2
 Default Biblio Status: current


### PR DESCRIPTION
We could alternatively rename the master branch to main and I think that would fix it too.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/caraitto/fenced-frame/pull/83.html" title="Last updated on May 2, 2023, 6:42 PM UTC (95fd52e)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/fenced-frame/83/99901d3...caraitto:95fd52e.html" title="Last updated on May 2, 2023, 6:42 PM UTC (95fd52e)">Diff</a>