### PR TITLE
Remove FencedFrameConfig#url

### DIFF
--- a/spec.bs
+++ b/spec.bs
@@ -962,7 +962,6 @@ maps to an internal [=fenced frame config=] [=struct=].
 
   [Exposed=Window]
   interface FencedFrameConfig {
-    readonly attribute FencedFrameConfigURL? url;
     readonly attribute FencedFrameConfigSize? containerWidth;
     readonly attribute FencedFrameConfigSize? containerHeight;
     readonly attribute FencedFrameConfigSize? contentWidth;
@@ -974,16 +973,6 @@ maps to an internal [=fenced frame config=] [=struct=].
 
 Each {{FencedFrameConfig}} has two internal members: <dfn for=fencedframeconfig>urn</dfn>, which is a
 [=urn uuid=], and <dfn for=fencedframeconfig>config</dfn>, which is a [=fenced frame config=].
-
-<div algorithm="url getter">
-  The {{FencedFrameConfig/url}} IDL attribute getter steps are:
-
-  1. If {{FencedFrameConfig}}'s [=fencedframeconfig/config=]'s [=fenced frame config/mapped url=]'s
-     [=mapped url/visibility=] is [=visibility/transparent=], return the [=fenced frame config/
-     mapped url=]'s [=mapped url/value=].
-
-  1. Otherwise, return `"opaque"`.
-</div>
 
 <div algorithm="containerWidth getter">
   The {{FencedFrameConfig/containerWidth}} IDL attribute getter steps are:


### PR DESCRIPTION
This supplements https://chromium-review.googlesource.com/c/chromium/src/+/4547401


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/WICG/fenced-frame/pull/88.html" title="Last updated on May 18, 2023, 3:22 PM UTC (cfdec94)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/fenced-frame/88/0f4d425...cfdec94.html" title="Last updated on May 18, 2023, 3:22 PM UTC (cfdec94)">Diff</a>