### PR TITLE
Address some early spec feedback

### DIFF
--- a/spec.bs
+++ b/spec.bs
@@ -1,5 +1,5 @@
 <pre class="metadata">
-Title: Fenced frame
+Title: Fenced Frame
 Shortname: fenced-frame
 Repository: WICG/fenced-frame
 Inline Github Issues: true
@@ -388,8 +388,15 @@ respective content attribute of the same name.
 
 This section details monkeypatches to [[!HTML]]'s <a
 href="https://html.spec.whatwg.org/multipage/embedded-content-other.html#dimension-attributes">Dimension
-attributes</a> section. This section will be updated to include <{fencedframe}> in the list of
-elements that the <code>[=width=]</code> and <code>[=height=]</code> dimension attributes apply to.
+attributes</a> section. That section will be updated to include <{fencedframe}> in the list of
+elements whose own <dfn element-attr for=fencedframe>width</dfn> and <dfn element-attr
+for=fencedframe>height</dfn> dimension attributes have the same author requirements that apply to
+the general <code>[=width=]</code> and <code>[=height=]</code> dimension attributes defined in
+[[HTML]].
+
+Furthermore, the IDL attributes <dfn attribute for=HTMLFencedFrameElement>width</dfn> and <dfn
+attribute for=HTMLFencedFrameElement>height</dfn> must [=reflect=] the respective content attributes
+of the same name.
 
 <h3 id=fenced-frame-config-map>Fenced frame config mapping</h3>
 


### PR DESCRIPTION
Mind taking a look @inexorabletash? This addresses the title capitalization as well as the width/height feedback (making the IDL attributes link to the ones now defined in this section, which reflect the now-defined content attributes etc.)


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/WICG/fenced-frame/pull/93.html" title="Last updated on May 24, 2023, 12:03 PM UTC (34ae4c6)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/fenced-frame/93/f3d2d23...34ae4c6.html" title="Last updated on May 24, 2023, 12:03 PM UTC (34ae4c6)">Diff</a>