### PR TITLE
Interest group descriptor string -> origin

### DIFF
--- a/spec.bs
+++ b/spec.bs
@@ -647,7 +647,7 @@ following [=struct/items=]:
 
 <dl export dfn-for="interest group descriptor">
   : <dfn>owner</dfn>
-  :: a [=string=]
+  :: an [=origin=]
 
   : <dfn>name</dfn>
   :: a [=string=]


### PR DESCRIPTION
I think it being a string was a boilerplate copy that I forgot to fix.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/WICG/fenced-frame/pull/103.html" title="Last updated on Jun 9, 2023, 7:39 PM UTC (4b08e56)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/fenced-frame/103/376d4d0...4b08e56.html" title="Last updated on Jun 9, 2023, 7:39 PM UTC (4b08e56)">Diff</a>