### PR TITLE
Fix finalize config procedure

### DIFF
--- a/spec.bs
+++ b/spec.bs
@@ -549,7 +549,8 @@ follows:
 
 <div algorithm>
   To <dfn for="fenced frame config mapping" export>finalize a pending config</dfn> in a [=fenced
-  frame config mapping=] |mapping| given a [=urn uuid=] |urn|, run these steps:
+  frame config mapping=] |mapping| given a [=urn uuid=] |urn| and [=fenced frame config=]
+  |config|, run these steps:
 
   1. Let |pendingMapping| be |mapping|'s [=fenced frame config mapping/pending config mapping=].
 
@@ -557,11 +558,9 @@ follows:
 
   1. If |pendingMapping|[|urn|] does not [=map/exist=], return failure.
 
-  1. Let |finalizedConfig| be |pendingMapping|[|urn|].
-
   1. [=map/Remove=] |pendingMapping|[|urn|].
 
-  1. [=map/Set=] |finalizedMapping|[|urn|] be |finalizedConfig|.
+  1. [=map/Set=] |finalizedMapping|[|urn|] to |config|.
 </div>
 
 <div algorithm>


### PR DESCRIPTION
Oops, you need to tell it what config value to finalize with... unless you keep a reference to the original pending config, but I think this is simpler.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/WICG/fenced-frame/pull/104.html" title="Last updated on Jun 14, 2023, 6:11 PM UTC (2d773c8)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/fenced-frame/104/2d2a330...2d773c8.html" title="Last updated on Jun 14, 2023, 6:11 PM UTC (2d773c8)">Diff</a>