### PR TITLE
Make FencedFrameConfig IDL objects serializable

### DIFF
--- a/spec.bs
+++ b/spec.bs
@@ -456,9 +456,13 @@ The <dfn attribute for=HTMLFencedFrameElement>config</dfn> IDL attribute getter 
 
   1. Let |urn uuid| be the given {{FencedFrameConfig}}'s [=fencedframeconfig/urn=].
 
+  1. Let |shared storage context| be the given {{FencedFrameConfig}}'s [=fencedframeconfig/
+     sharedStorageContext=].
+
   1. [=Navigate=] |element|'s [=fenced navigable container/fenced navigable=] to |urn uuid| using
      |element|'s [=Node/node document=], with [=historyHandling=] set to "<a for="history handling
-     behavior">`replace`</a>" , and [=referrerPolicy=] set to <a>"`no-referrer`"</a>.
+     behavior">`replace`</a>", [=referrerPolicy=] set to <a>"`no-referrer`"</a>, and
+     sharedStorageContext set to |shared storage context|.
 
      Note: See [[#navigation-changes]] for the <{fencedframe}>-specific changes to the ordinary
      navigation flow.
@@ -524,7 +528,7 @@ to discern when a pending config is finalized, it is important that all visibili
 transparent fields do not change from the pending config to the finalized config, given that they
 can be inspected through {{FencedFrameConfig}}'s getters. Therefore, a {{FencedFrameConfig}} that
 is created and exposed to the web platform is effectively immutable even if its underlying
-[=fencedframeconfig/config=] is technically "pending", and will finish resolving completely later.
+[=fenced frame config=] is technically "pending", and will finish resolving completely later.
 
 Each [=fenced frame config mapping=] has a <dfn for="fenced frame config mapping">maximum number of
 configs</dfn>, which is implementation-defined. The [=fenced frame config mapping/maximum number of
@@ -893,7 +897,7 @@ A <dfn export>fenced frame config</dfn> is a [=struct=] with the following [=str
     :: a [=URL=]
 
     : <dfn for="mapped url">visibility</dfn>
-    :: a [=visibility=]
+    :: a [=fencedframeconfig/visibility=]
 
   : <dfn>container size</dfn>
   :: null, or a [=fencedframetype/size=]
@@ -904,7 +908,7 @@ A <dfn export>fenced frame config</dfn> is a [=struct=] with the following [=str
     :: a [=fencedframetype/size=]
 
     : <dfn for="content size">visibility</dfn>
-    :: a [=visibility=]
+    :: a [=fencedframeconfig/visibility=]
 
   : <dfn>interest group descriptor</dfn>
   :: null, or a [=struct=] with the following [=struct/items=]:
@@ -912,7 +916,7 @@ A <dfn export>fenced frame config</dfn> is a [=struct=] with the following [=str
     :: an [=fencedframetype/interest group descriptor=]
 
     : <dfn for="interest group descriptor">visibility</dfn>
-    :: a [=visibility=]
+    :: a [=fencedframeconfig/visibility=]
 
   : <dfn>on navigate callback</dfn>
   :: null, or a series of steps
@@ -923,7 +927,7 @@ A <dfn export>fenced frame config</dfn> is a [=struct=] with the following [=str
     :: an [=fencedframetype/exhaustive set of sandbox flags=]
 
     : <dfn for="effective sandbox flags">visibility</dfn>
-    :: a [=visibility=]
+    :: a [=fencedframeconfig/visibility=]
 
   : <dfn>effective enabled permissions</dfn>
   :: null, or a [=struct=] with the following [=struct/items=]:
@@ -931,7 +935,7 @@ A <dfn export>fenced frame config</dfn> is a [=struct=] with the following [=str
     :: a [=list=] of [=policy-controlled features=]
 
     : <dfn for="effective enabled permissions">visibility</dfn>
-    :: a [=visibility=]
+    :: a [=fencedframeconfig/visibility=]
 
     Note: When non-null, this is a [=list=] of [=policy-controlled features=] that the generator of
     this config relies on exclusively being enabled inside the <{fencedframe}> that navigates to
@@ -951,7 +955,7 @@ A <dfn export>fenced frame config</dfn> is a [=struct=] with the following [=str
     :: a [=fencedframetype/fenced frame reporting metadata=]
 
     : <dfn for="fenced frame reporting metadata">visibility</dfn>
-    :: a [=visibility=]
+    :: a [=fencedframeconfig/visibility=]
 
   : <dfn>exfiltration budget metadata</dfn>
   :: null, or a [=struct=] with the following [=struct/items=]:
@@ -959,7 +963,7 @@ A <dfn export>fenced frame config</dfn> is a [=struct=] with the following [=str
     :: an [=fencedframetype/exfiltration budget metadata=]
 
     : <dfn for="exfiltration budget metadata">visibility</dfn>
-    :: a [=visibility=]
+    :: a [=fencedframeconfig/visibility=]
 
   : <dfn>nested configs</dfn>
   :: null, or a [=struct=] with the following [=struct/items=]:
@@ -967,7 +971,7 @@ A <dfn export>fenced frame config</dfn> is a [=struct=] with the following [=str
     :: a [=list=] of [=fenced frame configs=]
 
     : <dfn for="nested configs">visibility</dfn>
-    :: a [=visibility=]
+    :: a [=fencedframeconfig/visibility=]
 
   : <dfn>embedder shared storage context</dfn>
   :: null, or a [=string=]
@@ -1141,60 +1145,35 @@ element with arbitrary URLs *not* produced by config-generating APIs for develop
 Each {{FencedFrameConfig}} has:
 
  * A <dfn for=fencedframeconfig>urn</dfn>, a [=urn uuid=]
- * A <dfn for=fencedframeconfig>config</dfn>, a [=fenced frame config=]
+ * A <dfn for=fencedframeconfig>sharedStorageContext</dfn>, a [=string=]
+ * A <dfn for=fencedframeconfig>containerWidth</dfn>, a {{FencedFrameConfigSize}} or null
+ * A <dfn for=fencedframeconfig>containerHeight</dfn>, a {{FencedFrameConfigSize}} or null
+ * A <dfn for=fencedframeconfig>contentWidth</dfn>, a {{FencedFrameConfigSize}} or null
+ * A <dfn for=fencedframeconfig>contentHeight</dfn>, a {{FencedFrameConfigSize}} or null
 
 <div algorithm="containerWidth getter">
-  The {{FencedFrameConfig/containerWidth}} IDL attribute getter steps are:
-
-  1. If [=this=]'s [=fencedframeconfig/config=]'s [=fenced frame config/container size=] is null,
-     return null.
-
-  1. Return [=this=]'s [=fencedframeconfig/config=]'s [=fenced frame config/container size=]'s
-     [=size/width=].
+  The {{FencedFrameConfig/containerWidth}} IDL attribute getter steps are to return [=this=]'s
+  [=fencedframeconfig/containerWidth=].
 </div>
 
 <div algorithm="containerHeight getter">
-  The {{FencedFrameConfig/containerHeight}} IDL attribute getter steps are:
-
-  1. If [=this=]'s [=fencedframeconfig/config=]'s [=fenced frame config/container size=] is null,
-     return null.
-
-  1. Return [=this=]'s [=fencedframeconfig/config=]'s [=fenced frame config/container size=]'s
-     [=size/height=].
+  The {{FencedFrameConfig/containerHeight}} IDL attribute getter steps are to return [=this=]'s
+  [=fencedframeconfig/containerHeight=].
 </div>
 
 <div algorithm="contentWidth getter">
-  The {{FencedFrameConfig/contentWidth}} IDL attribute getter steps are:
-
-  1. If [=this=]'s [=fencedframeconfig/config=]'s [=fenced frame config/content size=] is null,
-     return null.
-
-  1. If [=this=]'s [=fencedframeconfig/config=]'s [=fenced frame config/content size=]'s [=content
-     size/visibility=] is "<a for=visibility>`transparent`</a>", return the [=fenced frame
-     config/content size=]'s [=content size/value=]'s [=size/width=].
-
-  1. Otherwise, return the `"opaque"` {{OpaqueProperty}}.
+  The {{FencedFrameConfig/contentWidth}} IDL attribute getter steps are to return [=this=]'s
+  [=fencedframeconfig/contentWidth=].
 </div>
 
 <div algorithm="contentHeight getter">
-  The {{FencedFrameConfig/contentHeight}} IDL attribute getter steps are:
-
-  1. If [=this=]'s [=fencedframeconfig/config=]'s [=fenced frame config/content size=] is null,
-     return null.
-
-  1. If [=this=]'s [=fencedframeconfig/config=]'s [=fenced frame config/content size=]'s [=content
-     size/visibility=] is "<a for=visibility>`transparent`</a>", return the [=fenced frame
-     config/content size=]'s [=content size/value=]'s [=size/height=].
-
-  1. Otherwise, return the `"opaque"` {{OpaqueProperty}}.
+  The {{FencedFrameConfig/contentHeight}} IDL attribute getter steps are to return [=this=]'s
+  [=fencedframeconfig/contentHeight=].
 </div>
 
 <div algorithm>
   The <dfn method for=FencedFrameConfig>setSharedStorageContext(|contextString|)</dfn> method steps
-  are:
-
-  1. Set [=this=]'s [=fencedframeconfig/config=]'s [=fenced frame config/embedder shared storage
-     context=] to |contextString|.
+  are to set [=this=]'s [=fencedframeconfig/sharedStorageContext=] to |contextString|.
 </div>
 
 <div algorithm="FencedFrameConfig serializer">
@@ -1203,9 +1182,24 @@ Each {{FencedFrameConfig}} has:
 
   1. If |forStorage| is true, then throw a {{DataCloneError}} {{DOMException}}.
   
-  2. Set |serialized|.`[[Urn]]` to the value of |value|'s [=fencedframeconfig/urn=] attribute.
+  1. Set |serialized|.`[[Urn]]` to the value of |value|'s [=fencedframeconfig/urn=] attribute.
 
-  3. Set |serialized|.`[[Config]]` to the value of |value|'s [=fencedframeconfig/config=] attribute.
+  1. Set |serialized|.`[[SharedStorageContext]]` to the value of |value|'s [=fencedframeconfig/
+     sharedStorageContext=] attribute.
+
+  1. Set |serialized|.`[[ContainerWidth]]` to the value of |value|'s [=fencedframeconfig/
+     containerWidth=] attribute.
+
+  1. Set |serialized|.`[[ContainerHeight]]` to the value of |value|'s [=fencedframeconfig/
+     containerHeight=] attribute.
+
+  1. Set |serialized|.`[[ContentWidth]]` to the value of |value|'s [=fencedframeconfig/
+     contentWidth=] attribute.
+
+  1. Set |serialized|.`[[ContentHeight]]` to the value of |value|'s [=fencedframeconfig/
+     contentHeight=] attribute.
+
+
 </div>
 
 <div algorithm="FencedFrameConfig deserializer">
@@ -1214,7 +1208,20 @@ Each {{FencedFrameConfig}} has:
 
   1. Initialize |value|'s [=fencedframeconfig/urn=] attribute to |serialized|.`[[Urn]]`.
 
-  2. Initialize |value|'s [=fencedframeconfig/config=] attribute to |serialized|.`[[Config]]`.
+  1. Initialize |value|'s [=fencedframeconfig/sharedStorageContext=] attribute to |serialized|.`
+     [[SharedStorageContext]]`.
+
+  1. Initialize |value|'s [=fencedframeconfig/containerWidth=] attribute to |serialized|.
+     `[[ContainerWidth]]`.
+
+  1. Initialize |value|'s [=fencedframeconfig/containerHeight=] attribute to |serialized|.
+     `[[ContainerHeight]]`.
+
+  1. Initialize |value|'s [=fencedframeconfig/contentWidth=] attribute to |serialized|.
+     `[[ContentWidth]]`.
+
+  1. Initialize |value|'s [=fencedframeconfig/contentHeight=] attribute to |serialized|.
+     `[[ContentHeight]]`.
 </div>
 
 <h3 id=fence-interface>The {{Fence}} interface</h3>
@@ -1334,8 +1341,28 @@ Several APIs specific to fenced frames are defined on the {{Fence}} interface.
         : [=fencedframeconfig/urn=]
         :: |urn|
 
-        : [=fencedframeconfig/config=]
-        :: |config|
+        : [=fencedframeconfig/sharedStorageContext=]
+        :: |config|'s [=fenced frame config/embedder shared storage context=]
+
+        : [=fencedframeconfig/containerWidth=]
+        :: null if |config|'s [=fenced frame config/container size=] is null, otherwise |config|'s
+           [=fenced frame config/container size=]'s [=size/width=]
+
+        : [=fencedframeconfig/containerHeight=]
+        :: null if |config|'s [=fenced frame config/container size=] is null, otherwise |config|'s
+           [=fenced frame config/container size=]'s [=size/height=]
+
+        : [=fencedframeconfig/contentWidth=]
+        :: null if |config|'s [=fenced frame config/content size=] is null, {{OpaqueProperty}} if
+           |config|'s [=fenced frame config/content size=]'s [=content size/visibility=] is
+           [=visibility/opaque=], otherwise |config|'s [=fenced frame config/content size=]'s
+           [=size/width=]
+
+        : [=fencedframeconfig/contentHeight=]
+        :: null if |config|'s [=fenced frame config/content size=] is null, {{OpaqueProperty}} if
+           |config|'s [=fenced frame config/content size=]'s [=content size/visibility=] is
+           [=visibility/opaque=], otherwise |config|'s [=fenced frame config/content size=]'s
+           [=size/height=]
 
      1. [=list/Append=] |newConfig| to |results|.
 
@@ -2117,6 +2144,9 @@ CORP violation report=] algorithm, as leaving it unfenced may cause a privacy le
 </div>
 
 <div algorithm=navigate>
+  Modify the beginning sentence of [[HTML]]'s [=navigate=] algorithm to include an extra parameter:
+  an optional [=string=] |sharedStorageContext| (default null).
+
   Modify step 7 of [[HTML]]'s [=navigate=] algorithm to include the following condition:
 
     * |navigable| is a [=fenced navigable container/fenced navigable=];
@@ -2142,7 +2172,7 @@ CORP violation report=] algorithm, as leaving it unfenced may cause a privacy le
     /fenced-frame/fragment-navigation.https.html
   </wpt>
 
-  Insert these steps immediately after step 16, the step that goes [=in parallel=], so that what
+  Insert these steps immediately after step 20, the step that goes [=in parallel=], so that what
   follows are the first steps that run [=in parallel=] in the patched algorithm:
 
     1. If |url| is a [=urn uuid=] and |navigable| is a [=fenced navigable container/fenced
@@ -2157,6 +2187,9 @@ CORP violation report=] algorithm, as leaving it unfenced may cause a privacy le
          mapping=]. This is why this step runs [=in parallel=]. This navigation will be canceled by
          any subsequent embedder-initiated navigations, <span class=allow-2119>should</span> they
          occur, by the usual mechanism that tracks the [=navigable/ongoing navigation=].
+
+      1. Set |config|'s [=fenced frame config/embedder shared storage context=] to
+         |sharedStorageContext|.
 
       1. Set <var ignore>sourceSnapshotParams</var>'s [=source snapshot params/target fenced frame
          config=] to |config|.
@@ -2453,22 +2486,21 @@ directive wouldn't give web sites enough control over their CSP rules. Introduce
 *This introductory sub-section is non-normative.*
 
 The [=policy-controlled features=] available to {{Document}}s inside of a <{fencedframe}> are
-determined exclusively by the {{FencedFrameConfig}} that the <{fencedframe}> navigates to.
-Specifically, the {{FencedFrameConfig}}'s [=fencedframeconfig/config=]'s [=fenced frame
-config/effective enabled permissions=] defines the exclusive list of [=policy-controlled features=]
-that will be enabled in the {{Document}} (all others will be disabled).
+determined exclusively by the [=fenced frame config=] that the <{fencedframe}> navigates to.
+Specifically, the [=fenced frame config=]'s [=fenced frame config/effective enabled permissions=]
+defines the exclusive list of [=policy-controlled features=] that will be enabled in the
+{{Document}} (all others will be disabled).
 
-During navigation, the {{FencedFrameConfig}}'s [=fencedframeconfig/config=] [=instantiate a
-config|instantiates=] a [=browsing context/fenced frame config instance=] that is stored on the
-[=browsing context=] in the [=fenced navigable container/fenced navigable=]. This browsing context's
-[=browsing context/fenced frame config instance=]'s [=fenced frame config instance/effective enabled
-permissions=] is consulted [=Should navigation response to navigation request be blocked by
-Permissions Policy?|during navigation=]. A <{fencedframe}> navigation can only succeed if the
-[=Document/permissions policy=] for the navigation's resulting {{Document}} has an [=permissions
-policy/inherited policy=] such that the [=inherited policy for a feature|inherited policy value=] is
-"`Enabled`" for each feature in the [=fenced frame config/effective enabled permissions=]. Otherwise
-the environment the <{fencedframe}> is embedded in is deemed unsuitable for the [=fenced frame
-config=], and the navigation is blocked.
+During navigation, the [=fenced frame config=] [=instantiate a config|instantiates=] a [=browsing
+context/fenced frame config instance=] that is stored on the [=browsing context=] in the [=fenced
+navigable container/fenced navigable=]. This browsing context's [=browsing context/fenced frame
+config instance=]'s [=fenced frame config instance/effective enabled permissions=] is consulted
+[=Should navigation response to navigation request be blocked by Permissions Policy?|during
+navigation=]. A <{fencedframe}> navigation can only succeed if the [=Document/permissions policy=]
+for the navigation's resulting {{Document}} has an [=permissions policy/inherited policy=] such that
+the [=inherited policy for a feature|inherited policy value=] is "`Enabled`" for each feature in the
+[=fenced frame config/effective enabled permissions=]. Otherwise the environment the <{fencedframe}>
+is embedded in is deemed unsuitable for the [=fenced frame config=], and the navigation is blocked.
 
 At the same time, to make sure that a <{fencedframe}>'s embedder does not directly influence content
 in the frame based on that navigation's [=navigation params/origin=] (since the origin is derived

--- a/spec.bs
+++ b/spec.bs
@@ -1190,8 +1190,8 @@ Each {{FencedFrameConfig}} has:
 </div>
 
 <div algorithm="FencedFrameConfig serializer">
-  {{FencedFrameConfig}} objects are [=serializable objects=]. Their
-  [=serialization steps=], given |value|, |serialized|, and |forStorage| are:
+  {{FencedFrameConfig}} objects are [=serializable objects=]. Their [=serialization steps=], given
+  |value|, |serialized|, and |forStorage| are:
 
   1. If |forStorage| is true, then throw a {{DataCloneError}} {{DOMException}}.
   
@@ -1202,8 +1202,7 @@ Each {{FencedFrameConfig}} has:
 
 <div algorithm="FencedFrameConfig deserializer">
   Their
-  [=deserialization steps=], given |serialized|, |value|, and <var ignore>
-  targetRealm</var> are:
+  [=deserialization steps=], given |serialized|, |value|, and <var ignore> targetRealm</var> are:
 
   1. Initialize |value|'s [=fencedframeconfig/urn=] attribute to |serialized|.`[[Urn]]`.
 

--- a/spec.bs
+++ b/spec.bs
@@ -526,9 +526,10 @@ returned to the web platform in a constant amount of time, before any computatio
 depends on cross-site data. Because the privacy of this depends on the web platform not being able
 to discern when a pending config is finalized, it is important that all visibilities and values of
 transparent fields do not change from the pending config to the finalized config, given that they
-can be inspected through {{FencedFrameConfig}}'s getters. Therefore, a {{FencedFrameConfig}} that
-is created and exposed to the web platform is effectively immutable even if its underlying
-[=fenced frame config=] is technically "pending", and will finish resolving completely later.
+can be inspected through {{FencedFrameConfig}}'s getters. Therefore, a {{FencedFrameConfig}} that is
+created and exposed to the web platform is effectively immutable even if the [=fenced frame config=]
+represented by the [=fencedframe/config=]'s [=fencedframeconfig/urn=] is technically "pending", and
+will finish resolving completely later.
 
 Each [=fenced frame config mapping=] has a <dfn for="fenced frame config mapping">maximum number of
 configs</dfn>, which is implementation-defined. The [=fenced frame config mapping/maximum number of
@@ -1182,46 +1183,43 @@ Each {{FencedFrameConfig}} has:
 
   1. If |forStorage| is true, then throw a {{DataCloneError}} {{DOMException}}.
   
-  1. Set |serialized|.`[[Urn]]` to the value of |value|'s [=fencedframeconfig/urn=] attribute.
+  1. Set |serialized|.\[[Urn]] to |value|'s [=fencedframeconfig/urn=].
 
-  1. Set |serialized|.`[[SharedStorageContext]]` to the value of |value|'s [=fencedframeconfig/
-     sharedStorageContext=] attribute.
+  1. Set |serialized|.\[[SharedStorageContext]] to |value|'s [=fencedframeconfig/
+     sharedStorageContext=].
 
-  1. Set |serialized|.`[[ContainerWidth]]` to the value of |value|'s [=fencedframeconfig/
-     containerWidth=] attribute.
+  1. Set |serialized|.\[[ContainerWidth]] to |value|'s [=fencedframeconfig/
+     containerWidth=].
 
-  1. Set |serialized|.`[[ContainerHeight]]` to the value of |value|'s [=fencedframeconfig/
-     containerHeight=] attribute.
+  1. Set |serialized|.\[[ContainerHeight]] to |value|'s [=fencedframeconfig/
+     containerHeight=].
 
-  1. Set |serialized|.`[[ContentWidth]]` to the value of |value|'s [=fencedframeconfig/
-     contentWidth=] attribute.
+  1. Set |serialized|.\[[ContentWidth]] to |value|'s [=fencedframeconfig/
+     contentWidth=].
 
-  1. Set |serialized|.`[[ContentHeight]]` to the value of |value|'s [=fencedframeconfig/
-     contentHeight=] attribute.
+  1. Set |serialized|.\[[ContentHeight]] to |value|'s [=fencedframeconfig/
+     contentHeight=].
 
 
 </div>
 
 <div algorithm="FencedFrameConfig deserializer">
-  Their
-  [=deserialization steps=], given |serialized|, |value|, and <var ignore> targetRealm</var> are:
+  Their [=deserialization steps=], given |serialized|, |value|, and <var ignore> targetRealm</var>
+  are:
 
-  1. Initialize |value|'s [=fencedframeconfig/urn=] attribute to |serialized|.`[[Urn]]`.
+  1. Initialize |value|'s [=fencedframeconfig/urn=] to |serialized|.\[[Urn]].
 
-  1. Initialize |value|'s [=fencedframeconfig/sharedStorageContext=] attribute to |serialized|.`
-     [[SharedStorageContext]]`.
+  1. Initialize |value|'s [=fencedframeconfig/sharedStorageContext=] to
+     |serialized|.\[[SharedStorageContext]].
 
-  1. Initialize |value|'s [=fencedframeconfig/containerWidth=] attribute to |serialized|.
-     `[[ContainerWidth]]`.
+  1. Initialize |value|'s [=fencedframeconfig/containerWidth=] to |serialized|.\[[ContainerWidth]].
 
-  1. Initialize |value|'s [=fencedframeconfig/containerHeight=] attribute to |serialized|.
-     `[[ContainerHeight]]`.
+  1. Initialize |value|'s [=fencedframeconfig/containerHeight=] to
+     |serialized|.\[[ContainerHeight]].
 
-  1. Initialize |value|'s [=fencedframeconfig/contentWidth=] attribute to |serialized|.
-     `[[ContentWidth]]`.
+  1. Initialize |value|'s [=fencedframeconfig/contentWidth=] to |serialized|.\[[ContentWidth]].
 
-  1. Initialize |value|'s [=fencedframeconfig/contentHeight=] attribute to |serialized|.
-     `[[ContentHeight]]`.
+  1. Initialize |value|'s [=fencedframeconfig/contentHeight=] to |serialized|.\[[ContentHeight]].
 </div>
 
 <h3 id=fence-interface>The {{Fence}} interface</h3>
@@ -1353,16 +1351,16 @@ Several APIs specific to fenced frames are defined on the {{Fence}} interface.
            [=fenced frame config/container size=]'s [=size/height=]
 
         : [=fencedframeconfig/contentWidth=]
-        :: null if |config|'s [=fenced frame config/content size=] is null, {{OpaqueProperty}} if
-           |config|'s [=fenced frame config/content size=]'s [=content size/visibility=] is
-           [=visibility/opaque=], otherwise |config|'s [=fenced frame config/content size=]'s
-           [=size/width=]
+        :: null if |config|'s [=fenced frame config/content size=] is null, the `"opaque"`
+           {{OpaqueProperty}} if |config|'s [=fenced frame config/content size=]'s [=content
+           size/visibility=] is [=visibility/opaque=], otherwise |config|'s [=fenced frame
+           config/content size=]'s [=size/width=]
 
         : [=fencedframeconfig/contentHeight=]
-        :: null if |config|'s [=fenced frame config/content size=] is null, {{OpaqueProperty}} if
-           |config|'s [=fenced frame config/content size=]'s [=content size/visibility=] is
-           [=visibility/opaque=], otherwise |config|'s [=fenced frame config/content size=]'s
-           [=size/height=]
+        :: null if |config|'s [=fenced frame config/content size=] is null, the `"opaque"`
+           {{OpaqueProperty}} if |config|'s [=fenced frame config/content size=]'s [=content
+           size/visibility=] is [=visibility/opaque=], otherwise |config|'s [=fenced frame
+           config/content size=]'s [=size/height=]
 
      1. [=list/Append=] |newConfig| to |results|.
 
@@ -2144,8 +2142,8 @@ CORP violation report=] algorithm, as leaving it unfenced may cause a privacy le
 </div>
 
 <div algorithm=navigate>
-  Modify the beginning sentence of [[HTML]]'s [=navigate=] algorithm to include an extra parameter:
-  an optional [=string=] |sharedStorageContext| (default null).
+  Modify the definition of [[HTML]]'s [=navigate=] algorithm to include an extra parameter: an
+  optional [=string=] |sharedStorageContext| (default null).
 
   Modify step 7 of [[HTML]]'s [=navigate=] algorithm to include the following condition:
 

--- a/spec.bs
+++ b/spec.bs
@@ -1114,7 +1114,7 @@ maps to an internal [=fenced frame config=] [=struct=].
   typedef (unsigned long or OpaqueProperty) FencedFrameConfigSize;
   typedef USVString FencedFrameConfigURL;
 
-  [Exposed=Window]
+  [Exposed=Window, Serializable]
   interface FencedFrameConfig {
     readonly attribute FencedFrameConfigSize? containerWidth;
     readonly attribute FencedFrameConfigSize? containerHeight;
@@ -1187,6 +1187,27 @@ Each {{FencedFrameConfig}} has:
 
   1. Set [=this=]'s [=fencedframeconfig/config=]'s [=fenced frame config/embedder shared storage
      context=] to |contextString|.
+</div>
+
+<div algorithm="FencedFrameConfig serializer">
+  {{FencedFrameConfig}} objects are [=serializable objects=]. Their
+  [=serialization steps=], given |value|, |serialized|, and |forStorage| are:
+
+  1. If |forStorage| is true, then throw a {{DataCloneError}} {{DOMException}}.
+  
+  2. Set |serialized|.`[[Urn]]` to the value of |value|'s [=fencedframeconfig/urn=] attribute.
+
+  3. Set |serialized|.`[[Config]]` to the value of |value|'s [=fencedframeconfig/config=] attribute.
+</div>
+
+<div algorithm="FencedFrameConfig deserializer">
+  Their
+  [=deserialization steps=], given |serialized|, |value|, and <var ignore>
+  targetRealm</var> are:
+
+  1. Initialize |value|'s [=fencedframeconfig/urn=] attribute to |serialized|.`[[Urn]]`.
+
+  2. Initialize |value|'s [=fencedframeconfig/config=] attribute to |serialized|.`[[Config]]`.
 </div>
 
 <h3 id=fence-interface>The {{Fence}} interface</h3>

--- a/spec.bs
+++ b/spec.bs
@@ -462,7 +462,7 @@ The <dfn attribute for=HTMLFencedFrameElement>config</dfn> IDL attribute getter 
   1. [=Navigate=] |element|'s [=fenced navigable container/fenced navigable=] to |urn uuid| using
      |element|'s [=Node/node document=], with [=historyHandling=] set to "<a for="history handling
      behavior">`replace`</a>", [=referrerPolicy=] set to <a>"`no-referrer`"</a>, and
-     sharedStorageContext set to |shared storage context|.
+     |shared storage context|.
 
      Note: See [[#navigation-changes]] for the <{fencedframe}>-specific changes to the ordinary
      navigation flow.


### PR DESCRIPTION
This PR:

- Makes `FencedFrameConfig` objects serializable and defines serializing/deserializing steps for it.
- Removes `config` as an attribute of a `FencedFrameConfig`, replacing it with a clone of the values it needs from the internal `Fenced Frame Config` struct.
- Passes in the `sharedStorageContext` directly to the `navigate` algorithm, which will read the `sharedStorageContext` from the IDL object to the `embedder shared storage context` in the `Fenced Frame Config` struct. This is done since we are no longer writing directly to the `Fenced Frame Config` struct in the `setSharedStorageContext()` algorithm.
- Modifies `getNestedConfigs()` to account for the changes to `FencedFrameConfig`.
- Update the step number for the `navigate` step that goes in parallel.
- Update the permissions policy introduction section to mention the internal `[=fenced frame config=]` struct instead of the `{{FencedFrameConfig}}` IDL object.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/WICG/fenced-frame/pull/111.html" title="Last updated on Aug 24, 2023, 5:33 PM UTC (4cfb07d)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/fenced-frame/111/7281202...4cfb07d.html" title="Last updated on Aug 24, 2023, 5:33 PM UTC (4cfb07d)">Diff</a>