### PR TITLE
Add Screen interface integration info.

### DIFF
--- a/explainer/integration_with_web_platform.md
+++ b/explainer/integration_with_web_platform.md
@@ -85,6 +85,9 @@ For more details, the implementation design doc can be found [here](https://docs
 
 For privacy implications of this API and others, see [the privacy considerations](https://github.com/WICG/fenced-frame/blob/master/explainer/README.md#privacy-considerations) section.
 
+## Screen Interface
+The [Screen interface](https://drafts.csswg.org/cssom-view/#the-screen-interface) provides information about the screen of the browser's output device, and as a result that information is visible to both fenced frames and the embedder. Currently there are no plans to fence the Screen interface, meaning that its attributes will retain the same values in both the fenced frames and their embedders. Justification for this decision can be found [here](https://docs.google.com/document/d/1sZOgnAUsIzNHOs_VVWF92er1jXmNCcv6k3vvOvixeFc/edit?usp=sharing). 
+
 ## Chromium implementation: Top-level browsing context using MPArch
 Chromium is implementing [Multiple Page Architecture](https://docs.google.com/document/d/1NginQ8k0w3znuwTiJ5qjYmBKgZDekvEPC22q0I4swxQ/edit?usp=sharing) for various use-cases including [back/forward-cache](https://web.dev/bfcache/), [portals](https://wicg.github.io/portals/), prerendering etc. This architecture aligns with fenced frames requirement to be a top-level browsing context as MPArch enables one WebContents to host multiple pages. Additionally, those pages could be nested, as is the requirement for fenced frames. 
 


### PR DESCRIPTION
The decision has been made to not fence Screen interface properties within fenced frames, see [doc](https://docs.google.com/document/d/1sZOgnAUsIzNHOs_VVWF92er1jXmNCcv6k3vvOvixeFc/edit?usp=sharing) for rationale. This PR documents that decision explicitly.