### PR TITLE
Update automatic beacon algorithm to send to all registered URLs

### DIFF
--- a/spec.bs
+++ b/spec.bs
@@ -1449,16 +1449,18 @@ successful [=navigate|navigation=] to a [=top-level traversable=].
   1. Let |beacon data| be |config|'s [=fenced frame config instance/fenced frame reporter=]'s
      [=fenced frame reporter/automatic beacon data=].
 
-  1. If |beacon data| is null, abort these steps.
+  1. Let |event data| be |beacon data|'s [=automatic beacon data/eventData=] if |beacon data| is not null, the empty string otherwise.
 
   1. If |sourceOrigin| is not [=same origin=] with |config|'s [=fenced frame config instance/mapped
      url=]'s [=url/origin=], abort these steps.
 
-  1. [=list/For each=] |destination| of |beacon data|'s [=automatic beacon data/destination=]:
+  1. [=list/For each=] |destination| of |config|'s [=fenced frame config instance/fenced frame reporter=]'s [=fenced frame reporter/fenced frame reporting metadata reference=]'s [=fencedframetype/fenced frame reporting map=]'s [=map/keys=]:
 
-    1. Run [=report an event=] using |config|'s [=fenced frame config instance/fenced frame
-       reporter=] with |destination|, |eventType|, and |beacon data|'s [=automatic beacon data/
-       eventData=].
+    1. If |beacon data|'s [=automatic beacon data/destinations=] [=list/contains=] |destination|, run [=report an event=] using |config|'s [=fenced frame config instance/fenced frame
+       reporter=] with |destination|, |eventType|, and |event data|.
+
+       Otherwise, run [=report an event=] using |config|'s [=fenced frame config instance/fenced frame
+       reporter=] with |destination|, |eventType|, and the empty string.
 
   1. If |beacon data|'s [=automatic beacon data/once=] is true, set |config|'s [=fenced frame
       config instance/fenced frame reporter=]'s [=fenced frame reporter/automatic beacon data=] to

--- a/spec.bs
+++ b/spec.bs
@@ -1475,6 +1475,7 @@ successful [=navigate|navigation=] to a [=top-level traversable=].
     /fenced-frame/automatic-beacon-two-events-clear.https.html
     /fenced-frame/automatic-beacon-two-events-persist.https.html
     /fenced-frame/automatic-beacon-unfenced-top.https.html
+    /fenced-frame/automatic-beacon-no-destination.https.html
   </wpt>
 </div>
 

--- a/spec.bs
+++ b/spec.bs
@@ -1449,18 +1449,22 @@ successful [=navigate|navigation=] to a [=top-level traversable=].
   1. Let |beacon data| be |config|'s [=fenced frame config instance/fenced frame reporter=]'s
      [=fenced frame reporter/automatic beacon data=].
 
-  1. Let |event data| be |beacon data|'s [=automatic beacon data/eventData=] if |beacon data| is not null, the empty string otherwise.
+  1. Let |event data| be |beacon data|'s [=automatic beacon data/eventData=] if |beacon data| is not
+     null, the empty string otherwise.
 
   1. If |sourceOrigin| is not [=same origin=] with |config|'s [=fenced frame config instance/mapped
      url=]'s [=url/origin=], abort these steps.
 
-  1. [=list/For each=] |destination| of |config|'s [=fenced frame config instance/fenced frame reporter=]'s [=fenced frame reporter/fenced frame reporting metadata reference=]'s [=fencedframetype/fenced frame reporting map=]'s [=map/keys=]:
+  1. [=list/For each=] |destination| of |config|'s [=fenced frame config instance/fenced frame
+     reporter=]'s [=fenced frame reporter/fenced frame reporting metadata reference=]'s
+     [=fencedframetype/fenced frame reporting map=]'s [=map/keys=]:
 
-    1. If |beacon data|'s [=automatic beacon data/destinations=] [=list/contains=] |destination|, run [=report an event=] using |config|'s [=fenced frame config instance/fenced frame
+    1. If |beacon data|'s [=automatic beacon data/destinations=] [=list/contains=] |destination|,
+       run [=report an event=] using |config|'s [=fenced frame config instance/fenced frame
        reporter=] with |destination|, |eventType|, and |event data|.
 
-       Otherwise, run [=report an event=] using |config|'s [=fenced frame config instance/fenced frame
-       reporter=] with |destination|, |eventType|, and the empty string.
+       Otherwise, run [=report an event=] using |config|'s [=fenced frame config instance/fenced
+       frame reporter=] with |destination|, |eventType|, and the empty string.
 
   1. If |beacon data|'s [=automatic beacon data/once=] is true, set |config|'s [=fenced frame
       config instance/fenced frame reporter=]'s [=fenced frame reporter/automatic beacon data=] to


### PR DESCRIPTION
Automatic beacons will now send to all URLs that registered with the reserved.top_navigation event type, regardless of what data was set when calling setReportEventDataForAutomaticBeacons(). However, automatic beacon data will only be included in the beacon if the beacon's destination is specified in the destination field when calling setReportEventDataForAutomaticBeacons().


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/WICG/fenced-frame/pull/122.html" title="Last updated on Sep 22, 2023, 3:15 PM UTC (d598d24)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/fenced-frame/122/bd99c82...d598d24.html" title="Last updated on Sep 22, 2023, 3:15 PM UTC (d598d24)">Diff</a>