### PR TITLE
Spec for attribution reporting integration

### DIFF
--- a/spec.bs
+++ b/spec.bs
@@ -251,9 +251,6 @@ spec: attribution-reporting; urlPrefix: https://wicg.github.io/attribution-repor
       text: event-source; url:eligibility-event-source
       text: navigation-source; url:eligibility-navigation-source
       text: unset; url:eligibility-unset
-    for: request
-      text: Attribution Reporting eligibility
-    text: process an attribution eligible response
 </pre>
 
 <style>

--- a/spec.bs
+++ b/spec.bs
@@ -794,7 +794,7 @@ A <dfn export for=fencedframetype>destination enum event</dfn> is a [=struct=] w
   : <dfn>attributionReportingEnabled</dfn>
   :: a [=boolean=]
 
-  : <dfn>contextOrigin</dfn>
+  : <dfn>attributionReportingContextOrigin</dfn>
   :: an [=origin=]
 </dl>
 
@@ -828,7 +828,7 @@ A <dfn export for=fencedframetype>destination event</dfn> is either a
 
     1. If |event|'s [=destination enum event/attributionReportingEnabled=] is true and the result
        of [=getting supported registrars=] is not [=list/is empty|empty=] and |event|'s
-       [=destination enum event/contextOrigin=] [=check if an origin is suitable|is suitable=]:
+       [=destination enum event/attributionReportingContextOrigin=] [=check if an origin is suitable|is suitable=]:
 
         1. If |event|'s [=destination enum event/type=] is `"reserved.top_navigation"`,
            set |attributionReportingEligibility| to "<code>[=eligibility/navigation-source=]</code>".
@@ -838,7 +838,7 @@ A <dfn export for=fencedframetype>destination event</dfn> is either a
         1. Set |processResponse| to these steps given a [=response=] |response|:
 
            1. Run [=process an attribution eligible response=] with |event|'s
-              [=destination enum event/contextOrigin=], |attributionReportingEligibility|, and |response|.
+              [=destination enum event/attributionReportingContextOrigin=], |attributionReportingEligibility|, and |response|.
 
         1. Set |useParallelQueue| to true.
 
@@ -1497,7 +1497,7 @@ Several APIs specific to fenced frames are defined on the {{Fence}} interface.
         1. Let |attributionReportingEnabled| be the result of determining whether |document| is
            [=allowed to use=] the "<code>{{PermissionPolicy/attribution-reporting}}</code>" feature.
 
-        1. Let |contextOrigin| be |document|'s [=node/context origin=].
+        1. Let |attributionReportingContextOrigin| be |document|'s [=node/context origin=].
 
         1. [=list/For each=] |destination| of |event|'s {{FenceEvent/destination}}:
 
@@ -1514,8 +1514,8 @@ Several APIs specific to fenced frames are defined on the {{Fence}} interface.
            : [=destination enum event/attributionReportingEnabled=]
            :: |attributionReportingEnabled|
 
-           : [=destination enum event/contextOrigin=]
-           :: |contextOrigin|
+           : [=destination enum event/attributionReportingContextOrigin=]
+           :: |attributionReportingContextOrigin|
 
   <wpt>
     /fenced-frame/fence-report-event.https.html
@@ -1716,7 +1716,7 @@ successful [=navigate|navigation=] to a [=top-level traversable=].
        : [=destination enum event/attributionReportingEnabled=]
        :: |sourceSnapshotParams|'s [=source snapshot params/attribution reporting enabled=]
 
-       : [=destination enum event/contextOrigin=]
+       : [=destination enum event/attributionReportingContextOrigin=]
        :: |sourceSnapshotParams|'s [=source snapshot params/attribution reporting context origin=]
 
   1. If |beacon data|'s [=automatic beacon data/once=] is true, set |config|'s [=fenced frame

--- a/spec.bs
+++ b/spec.bs
@@ -1717,7 +1717,7 @@ successful [=navigate|navigation=] to a [=top-level traversable=].
        :: |sourceSnapshotParams|'s [=source snapshot params/attribution reporting enabled=]
 
        : [=destination enum event/contextOrigin=]
-       :: |sourceSnapshotParams|'s [=source snapshot params/context origin=]
+       :: |sourceSnapshotParams|'s [=source snapshot params/attribution reporting context origin=]
 
   1. If |beacon data|'s [=automatic beacon data/once=] is true, set |config|'s [=fenced frame
       config instance/fenced frame reporter=]'s [=fenced frame reporter/automatic beacon data=] to
@@ -2392,7 +2392,7 @@ CORP violation report=] algorithm, as leaving it unfenced may cause a privacy le
   : <dfn for="source snapshot params">attribution reporting enabled</dfn>
   :: a [=boolean=].
 
-  : <dfn for="source snapshot params">context origin</dfn>
+  : <dfn for="source snapshot params">attribution reporting context origin</dfn>
   :: an [=origin=].
 
   Note: The [=source snapshot params/initiator fenced frame config instance=] is the [=fenced frame
@@ -2417,7 +2417,7 @@ CORP violation report=] algorithm, as leaving it unfenced may cause a privacy le
   :: The result of determining whether |sourceDocument| is [=allowed to use=] the
      "<code>{{PermissionPolicy/attribution-reporting}}</code>" feature
 
-  : [=source snapshot params/context origin=]
+  : [=source snapshot params/attribution reporting context origin=]
   :: |sourceDocument|'s [=node/context origin=]
 
 </div>

--- a/spec.bs
+++ b/spec.bs
@@ -911,7 +911,8 @@ A <dfn export for=fencedframetype>destination event</dfn> is either a
     Note: This algorithm can be invoked from while [=in parallel=] or while on a {{Document}}'s main
     thread. To handle the [=in parallel=] invocation correctly, we invoke [=fetch=]
     with [=fetch/useParallelQueue=] set to true when the <span class=allow-2119>optional</span>
-    [=response=]-handling algorithm is used, otherwise there is no need to do this.
+    [=response=]-handling algorithm is used, otherwise there is no need to do this even when this
+    algorithm is running [=in parallel=] in other instances.
 </div>
 
 <div algorithm>

--- a/spec.bs
+++ b/spec.bs
@@ -248,9 +248,9 @@ spec: css2; urlPrefix: https://www.w3.org/TR/CSS21/visuren.html
 spec: attribution-reporting; urlPrefix: https://wicg.github.io/attribution-reporting-api/
   type: dfn
     for: eligibility
-      text: event-source; url:eligibility-event-source
-      text: navigation-source; url:eligibility-navigation-source
-      text: unset; url:eligibility-unset
+      text: event-source; url: eligibility-event-source
+      text: navigation-source; url: eligibility-navigation-source
+      text: unset; url: eligibility-unset
 </pre>
 
 <style>

--- a/spec.bs
+++ b/spec.bs
@@ -1665,9 +1665,8 @@ successful [=navigate|navigation=] to a [=top-level traversable=].
 
 <div algorithm>
   To <dfn>attempt to send an automatic beacon</dfn> given a [=source snapshot params=]
-  |sourceSnapshotParams|, an [=origin=] |sourceOrigin|, a {{Document}} |targetDocument|, a
-  [=string=] |eventType|, a [=boolean=] |attributionReportingEnabled|, and an [=origin=]
-  |contextOrigin|, run these steps:
+  |sourceSnapshotParams|, an [=origin=] |sourceOrigin|, a {{Document}} |targetDocument|, and a
+  [=string=] |eventType|, run these steps:
 
   1. [=Assert=]: |eventType| is "`reserved.top_navigation`".
 
@@ -1715,10 +1714,10 @@ successful [=navigate|navigation=] to a [=top-level traversable=].
        :: |eventData|
 
        : [=destination enum event/attributionReportingEnabled=]
-       :: |attributionReportingEnabled|
+       :: |sourceSnapshotParams|'s [=source snapshot params/attribution reporting enabled=]
 
        : [=destination enum event/contextOrigin=]
-       :: |contextOrigin|
+       :: |sourceSnapshotParams|'s [=source snapshot params/context origin=]
 
   1. If |beacon data|'s [=automatic beacon data/once=] is true, set |config|'s [=fenced frame
       config instance/fenced frame reporter=]'s [=fenced frame reporter/automatic beacon data=] to
@@ -1734,22 +1733,12 @@ successful [=navigate|navigation=] to a [=top-level traversable=].
 </div>
 
 <div algorithm="automatic beacon patch">
-  Modify [[HTML]]'s [=attempt to populate the history entry's document=] algorithm in the following ways.
-
-  First, add steps after step 5 that reads:
-
-  6. Let |attributionReportingEnabled| be the result of determining whether |navigable|'s
-     [=navigable/active document=] is [=allowed to use=] the "<code>{{PermissionPolicy/attribution-reporting}}</code>"
-     feature.
-
-  1. Let |contextOrigin| be |navigable|'s [=navigable/active document=]'s [=node/context origin=].
-
-  Second, in step 6, substep 11, add a new step after step 5 that reads:
+  Modify [[HTML]]'s [=attempt to populate the history entry's document=] algorithm. In step 6,
+  substep 11, add a new step after step 5 that reads:
 
   6. if <var ignore>failure</var> is false, then [=attempt to send an automatic beacon=] given <var
      ignore>sourceSnapshotParams</var>, <var ignore>entry</var>'s [=document state=]'s [=document
-     state/initiator origin=], <var ignore>document</var>, "`reserved.top_navigation`", |attributionReportingEnabled|,
-     and |contextOrigin|.
+     state/initiator origin=], <var ignore>document</var>, and "`reserved.top_navigation`".
 </div>
 
 <h2 id=html-integration>HTML Integration</h2>
@@ -2392,13 +2381,19 @@ CORP violation report=] algorithm, as leaving it unfenced may cause a privacy le
 <h4 id=navigation-changes>Actual navigation changes</h4>
 
 <div algorithm=source-snapshot-param-config>
-  Add two new [=struct/item=]s to the [=source snapshot params=] [=struct=]:
+  Add four new [=struct/item=]s to the [=source snapshot params=] [=struct=]:
 
   : <dfn for="source snapshot params">initiator fenced frame config instance</dfn>
   :: a [=fenced frame config instance=] or null, initially null.
 
   : <dfn for="source snapshot params">target fenced frame config</dfn>
   :: a [=fenced frame config=] or null, initially null.
+
+  : <dfn for="source snapshot params">attribution reporting enabled</dfn>
+  :: a [=boolean=].
+
+  : <dfn for="source snapshot params">context origin</dfn>
+  :: an [=origin=].
 
   Note: The [=source snapshot params/initiator fenced frame config instance=] is the [=fenced frame
   config instance=] that's loaded into a navigation initiator's [=browsing context=], if any exists.
@@ -2412,11 +2407,19 @@ CORP violation report=] algorithm, as leaving it unfenced may cause a privacy le
 
 <div algorithm=snapshot-source-snapshot-params>
   Modify the [=snapshot source snapshot params=] algorithm to return a [=source snapshot params=]
-  with an additional field:
+  with three additional fields:
 
   : [=source snapshot params/initiator fenced frame config instance=]
-  :: <var ignore>sourceDocument</var>'s [=browsing context=]'s [=browsing context/fenced frame
+  :: |sourceDocument|'s [=browsing context=]'s [=browsing context/fenced frame
      config instance=]
+
+  : [=source snapshot params/attribution reporting enabled=]
+  :: The result of determining whether |sourceDocument| is [=allowed to use=] the
+     "<code>{{PermissionPolicy/attribution-reporting}}</code>" feature
+
+  : [=source snapshot params/context origin=]
+  :: |sourceDocument|'s [=node/context origin=]
+
 </div>
 
 <div algorithm=navigate>

--- a/spec.bs
+++ b/spec.bs
@@ -245,6 +245,15 @@ spec: css2; urlPrefix: https://www.w3.org/TR/CSS21/visuren.html
   type: dfn
     for: css2
       text: viewport; url: viewport
+spec: attribution-reporting; urlPrefix: https://wicg.github.io/attribution-reporting-api/
+  type: dfn
+    for: eligibility
+      text: event-source; url:eligibility-event-source
+      text: navigation-source; url:eligibility-navigation-source
+      text: unset; url:eligibility-unset
+    for: request
+      text: Attribution Reporting eligibility
+    text: process an attribution eligible response
 </pre>
 
 <style>
@@ -784,6 +793,12 @@ A <dfn export for=fencedframetype>destination enum event</dfn> is a [=struct=] w
 
   : <dfn>data</dfn>
   :: a [=string=]
+
+  : <dfn>attributionReportingEnabled</dfn>
+  :: a [=boolean=]
+
+  : <dfn>contextOrigin</dfn>
+  :: an [=origin=]
 </dl>
 
 A <dfn export for=fencedframetype>destination URL event</dfn> is a [=URL=].
@@ -797,6 +812,12 @@ A <dfn export for=fencedframetype>destination event</dfn> is either a
 
   1. Let |destination url| be an empty [=string=].
 
+  1. Let |attributionReportingEligibility| be "<code>[=eligibility/unset=]</code>".
+
+  1. Let |processResponse| be null.
+
+  1. Let |useParallelQueue| be false.
+
   1. If |event| is a [=fencedframetype/destination enum event=], then:
 
      1. Let |destination map| be |destination info|'s
@@ -807,6 +828,22 @@ A <dfn export for=fencedframetype>destination event</dfn> is either a
      1. If |destination map|[|eventType|] does not [=map/exist=], return.
 
      1. Set |destination url| to |destination map|[|eventType|].
+
+    1. If |event|'s [=destination enum event/attributionReportingEnabled=] is true and the result
+       of [=getting supported registrars=] is not [=list/is empty|empty=] and |event|'s
+       [=destination enum event/contextOrigin=] [=check if an origin is suitable|is suitable=]:
+
+        1. If |event|'s [=destination enum event/type=] is `"reserved.top_navigation"`,
+           set |attributionReportingEligibility| to "<code>[=eligibility/navigation-source=]</code>".
+
+        1. Otherwise, set |attributionReportingEligibility| to "<code>[=eligibility/event-source=]</code>".
+
+        1. Set |processResponse| to these steps given a [=response=] |response|:
+
+           1. Run [=process an attribution eligible response=] with |event|'s
+              [=destination enum event/contextOrigin=], |attributionReportingEligibility|, and |response|.
+
+        1. Set |useParallelQueue| to true.
 
   1. Otherwise:
 
@@ -868,12 +905,16 @@ A <dfn export for=fencedframetype>destination event</dfn> is either a
     : [=request/credentials mode=]
     :: `"omit"`
 
-  1. [=Fetch=] |request|.
+    : [=request/Attribution Reporting eligibility=]
+    :: |attributionReportingEligibility|
+
+  1. [=Fetch=] |request| with [=fetch/processResponse=] being |processResponse| if it is not null
+     and [=fetch/useParallelQueue=] being |useParallelQueue|.
 
     Note: This algorithm can be invoked from while [=in parallel=] or while on a {{Document}}'s main
-    thread. To handle the [=in parallel=] invocation correctly, ordinarily we would invoke [=fetch=]
-    with [=fetch/useParallelQueue=] set to true, but since we don't pass in any of the <span
-    class=allow-2119>optional</span> [=response=]-handling algorithms, there is no need to do this.
+    thread. To handle the [=in parallel=] invocation correctly, we invoke [=fetch=]
+    with [=fetch/useParallelQueue=] set to true when the <span class=allow-2119>optional</span>
+    [=response=]-handling algorithm is used, otherwise there is no need to do this.
 </div>
 
 <div algorithm>
@@ -1453,6 +1494,13 @@ Several APIs specific to fenced frames are defined on the {{Fence}} interface.
 
            1. [=exception/Throw=] a {{TypeError}}.
 
+        1. Let |document| be [=this=]'s [=relevant global object=]'s [=associated Document=].
+
+        1. Let |attributionReportingEnabled| be the result of determining whether |document| is
+           [=allowed to use=] the "<code>{{PermissionPolicy/attribution-reporting}}</code>" feature.
+
+        1. Let |contextOrigin| be |document|'s [=node/context origin=].
+
         1. [=list/For each=] |destination| of |event|'s {{FenceEvent/destination}}:
 
         1. Run [=report an event=] using |instance|'s [=fenced frame config instance/fenced frame
@@ -1464,6 +1512,12 @@ Several APIs specific to fenced frames are defined on the {{Fence}} interface.
 
            : [=destination enum event/data=]
            :: |event|'s {{FenceEvent/eventData}} (or the empty string if it is not defined).
+
+           : [=destination enum event/attributionReportingEnabled=]
+           :: |attributionReportingEnabled|
+
+           : [=destination enum event/contextOrigin=]
+           :: |contextOrigin|
 
   <wpt>
     /fenced-frame/fence-report-event.https.html
@@ -1607,14 +1661,15 @@ A side effect of the fenced boundary model is that ads will lose the ability to 
 resulted in a successful navigation. This is because the page loaded from a top-level [=navigate|
 navigation=] originating from a fenced frame will not be allowed to report to the fenced frame that
 it loaded (through something like <code>window.[=Window/opener=]</code>). Instead, we introduce a
-special event-level [=pending event/eventType|reporting type=], `reserved.top_navigation`, which
+special event-level [=destination enum event/type|reporting type=], `reserved.top_navigation`, which
 automatically sends an [=report an event|event-level beacon=] when a fenced frame initiates a
 successful [=navigate|navigation=] to a [=top-level traversable=].
 
 <div algorithm>
   To <dfn>attempt to send an automatic beacon</dfn> given a [=source snapshot params=]
-  |sourceSnapshotParams|, an [=origin=] |sourceOrigin|, a {{Document}} |targetDocument|, and a
-  [=string=] |eventType|, run these steps:
+  |sourceSnapshotParams|, an [=origin=] |sourceOrigin|, a {{Document}} |targetDocument|, a
+  [=string=] |eventType|, a [=boolean=] |attributionReportingEnabled|, and an [=origin=]
+  |contextOrigin|, run these steps:
 
   1. [=Assert=]: |eventType| is "`reserved.top_navigation`".
 
@@ -1646,12 +1701,26 @@ successful [=navigate|navigation=] to a [=top-level traversable=].
      reporter=]'s [=fenced frame reporter/fenced frame reporting metadata reference=]'s
      [=fencedframetype/fenced frame reporting map=]'s [=map/keys=]:
 
-    1. If |beacon data|'s [=automatic beacon data/destinations=] [=list/contains=] |destination|,
-       run [=report an event=] using |config|'s [=fenced frame config instance/fenced frame
-       reporter=] with |destination|, |eventType|, and |event data|.
+    1. Let |eventData| be an empty [=string=].
 
-       Otherwise, run [=report an event=] using |config|'s [=fenced frame config instance/fenced
-       frame reporter=] with |destination|, |eventType|, and the empty string.
+    1. If |beacon data|'s [=automatic beacon data/destinations=] [=list/contains=] |destination|,
+       set |eventData| to |event data|.
+
+    1. Run [=report an event=] using |config|'s [=fenced frame config instance/fenced frame
+       reporter=] with |destination| and a [=fencedframetype/destination enum event=] with the
+       following [=struct/items=]:
+
+       : [=destination enum event/type=]
+       :: |eventType|
+
+       : [=destination enum event/data=]
+       :: |eventData|
+
+       : [=destination enum event/attributionReportingEnabled=]
+       :: |attributionReportingEnabled|
+
+       : [=destination enum event/contextOrigin=]
+       :: |contextOrigin|
 
   1. If |beacon data|'s [=automatic beacon data/once=] is true, set |config|'s [=fenced frame
       config instance/fenced frame reporter=]'s [=fenced frame reporter/automatic beacon data=] to
@@ -1667,12 +1736,22 @@ successful [=navigate|navigation=] to a [=top-level traversable=].
 </div>
 
 <div algorithm="automatic beacon patch">
-  Modify [[HTML]]'s [=attempt to populate the history entry's document=] algorithm. In step 6,
-  substep 11, add a new step after step 5 that reads:
+  Modify [[HTML]]'s [=attempt to populate the history entry's document=] algorithm in the following ways.
+
+  First, add steps after step 5 that reads:
+
+  6. Let |attributionReportingEnabled| be the result of determining whether |navigable|'s
+     [=navigable/active document=] is [=allowed to use=] the "<code>{{PermissionPolicy/attribution-reporting}}</code>"
+     feature.
+
+  1. Let |contextOrigin| be |navigable|'s [=navigable/active document=]'s [=node/context origin=].
+
+  Second, in step 6, substep 11, add a new step after step 5 that reads:
 
   6. if <var ignore>failure</var> is false, then [=attempt to send an automatic beacon=] given <var
      ignore>sourceSnapshotParams</var>, <var ignore>entry</var>'s [=document state=]'s [=document
-     state/initiator origin=], <var ignore>document</var>, and "`reserved.top_navigation`".
+     state/initiator origin=], <var ignore>document</var>, "`reserved.top_navigation`", |attributionReportingEnabled|,
+     and |contextOrigin|.
 </div>
 
 <h2 id=html-integration>HTML Integration</h2>


### PR DESCRIPTION
This is migrated from the monkeypatches in attribution reporting API spec: https://wicg.github.io/attribution-reporting-api/#fenced-frame-monkeypatches

Also spec'ed the integration for automatic beacon.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/linnan-github/fenced-frame/pull/127.html" title="Last updated on Oct 12, 2023, 3:30 PM UTC (a7b975f)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/fenced-frame/127/ed8c323...linnan-github:a7b975f.html" title="Last updated on Oct 12, 2023, 3:30 PM UTC (a7b975f)">Diff</a>