### PR TITLE
Spec reserved.top_navigation_start and reserved.top_navigation_commit

### DIFF
--- a/spec.bs
+++ b/spec.bs
@@ -1746,16 +1746,16 @@ traversable=].
 <div algorithm="top_navigation_start beacon patch">
   Modify [[HTML]]'s [=navigate=] algorithm. Add a new step after step 4 that reads:
   
-  5. [=attempt to send an automatic beacon=] given <var ignore>sourceDocument</var>, <var
-     ignore>sourceSnapshotParams</var>, <var ignore>navigable</var>’s associated {{Document}}, and
-     "`reserved.top_navigation_start`".
+  5. [=Attempt to send an automatic beacon=] given <var ignore>sourceSnapshotParams</var>, <var
+     ignore>initiatorOriginSnapshot</var>, <var ignore>navigable</var>’s associated {{Document}},
+     and "`reserved.top_navigation_start`".
 </div>
 
 <div algorithm="top_navigation_commit beacon patch">
   Modify [[HTML]]'s [=attempt to populate the history entry's document=] algorithm. In step 6,
   substep 11, add a new step after step 5 that reads:
 
-  6. if <var ignore>failure</var> is false, then [=attempt to send an automatic beacon=] given <var
+  6. If <var ignore>failure</var> is false, then [=attempt to send an automatic beacon=] given <var
      ignore>sourceSnapshotParams</var>, <var ignore>entry</var>'s [=document state=]'s [=document
      state/initiator origin=], <var ignore>document</var>, and "`reserved.top_navigation_commit`".
 </div>

--- a/spec.bs
+++ b/spec.bs
@@ -762,8 +762,14 @@ following [=struct/items=]:
 </dl>
 
 An <dfn for=fencedframetype>automatic beacon event type</dfn> is either "<dfn
-for="automatic beacon event type">`reserved.top_navigation_start`</dfn>" or "<dfn
-for="automatic beacon event type">`reserved.top_navigation_commit`</dfn>".
+for="automatic beacon event type">`reserved.top_navigation_start`</dfn>", "<dfn
+for="automatic beacon event type">`reserved.top_navigation_commit`</dfn>", or "<dfn
+for="automatic beacon event type">`reserved.top_navigation`</dfn>".
+
+Advisement: <code>[=automatic beacon event type/reserved.top_navigation=]</code> is an earlier
+naming of <code>[=automatic beacon event type/reserved.top_navigation_commit=]</code>. While they
+both do the same thing, <code>[=automatic beacon event type/reserved.top_navigation=]</code> will be
+depreacted in the future and should not be used for new code.
 
 An <dfn for=fencedframetype>automatic beacon data</dfn> is a [=struct=] with the following
 [=struct/items=]:
@@ -1690,10 +1696,11 @@ A side effect of the fenced boundary model is that ads will lose the ability to 
 resulted in a successful navigation. This is because the page loaded from a top-level [=navigate|
 navigation=] originating from a fenced frame will not be allowed to report to the fenced frame that
 it loaded (through something like <code>window.[=Window/opener=]</code>). Instead, we introduce
-special event-level [=destination enum event/type|reporting type=]s, `reserved.top_navigation_start`
-and `resrved.top_navigation_commit`, which automatically sends an [=report an event|event-level
-beacon=] when a fenced frame initiates a successful [=navigate|navigation=] to a [=top-level
-traversable=].
+special event-level [=automatic beacon event/type|reporting type=]s, <code>[=automatic beacon event
+type/reserved.top_navigation_start=]</code> and <code>[=automatic beacon event
+type/reserved.top_navigation_commit=]</code>, which automatically sends an [=report an
+event|event-level beacon=] when a fenced frame initiates a successful [=navigate|navigation=] to a
+[=top-level traversable=].
 
 <div algorithm>
   To <dfn>attempt to send an automatic beacon</dfn> given a [=source snapshot params=]
@@ -1763,17 +1770,24 @@ traversable=].
   
   5. [=Attempt to send an automatic beacon=] given <var ignore>sourceSnapshotParams</var>, <var
      ignore>initiatorOriginSnapshot</var>, <var ignore>navigable</var>’s associated {{Document}},
-     and "[=automatic beacon event type/reserved.top_navigation_start=]".
+     and <code>[=automatic beacon event type/reserved.top_navigation_start=]</code>.
 </div>
 
 <div algorithm="top_navigation_commit beacon patch">
   Modify [[HTML]]'s [=attempt to populate the history entry's document=] algorithm. In step 6,
   substep 11, add a new step after step 5 that reads:
 
-  6. If <var ignore>failure</var> is false, then [=attempt to send an automatic beacon=] given <var
-     ignore>sourceSnapshotParams</var>, <var ignore>entry</var>'s [=document state=]'s [=document
-     state/initiator origin=], <var ignore>document</var>, and "[=automatic beacon event
-     type/reserved.top_navigation_commit=]".
+  6. If <var ignore>failure</var> is false, then:
+    
+    1. [=Attempt to send an automatic beacon=] given <var
+       ignore>sourceSnapshotParams</var>, <var ignore>entry</var>'s [=document state=]'s [=document
+       state/initiator origin=], <var ignore>document</var>, and <code>[=automatic beacon event
+       type/reserved.top_navigation_commit=]</code>.
+    
+    1. [=Attempt to send an automatic beacon=] given <var
+       ignore>sourceSnapshotParams</var>, <var ignore>entry</var>'s [=document state=]'s [=document
+       state/initiator origin=], <var ignore>document</var>, and <code>[=automatic beacon event
+       type/reserved.top_navigation=]</code>.
 </div>
 
 <h2 id=html-integration>HTML Integration</h2>

--- a/spec.bs
+++ b/spec.bs
@@ -769,7 +769,7 @@ for="automatic beacon event type">`reserved.top_navigation`</dfn>".
 Advisement: <code>[=automatic beacon event type/reserved.top_navigation=]</code> is an earlier
 naming of <code>[=automatic beacon event type/reserved.top_navigation_commit=]</code>. While they
 both do the same thing, <code>[=automatic beacon event type/reserved.top_navigation=]</code> will be
-depreacted in the future and should not be used for new code.
+removed in the future and should not be used for new code.
 
 An <dfn for=fencedframetype>automatic beacon data</dfn> is a [=struct=] with the following
 [=struct/items=]:

--- a/spec.bs
+++ b/spec.bs
@@ -761,14 +761,14 @@ following [=struct/items=]:
   :: a [=boolean=], initially false
 </dl>
 
-An <dfn export for=fencedframetype>automatic beacon event type</dfn> is either "<dfn export
-for="automatic beacon event type">`reserved.top_navigation_start`</dfn>" or "<dfn export
+An <dfn for=fencedframetype>automatic beacon event type</dfn> is either "<dfn
+for="automatic beacon event type">`reserved.top_navigation_start`</dfn>" or "<dfn
 for="automatic beacon event type">`reserved.top_navigation_commit`</dfn>".
 
-An <dfn export for=fencedframetype>automatic beacon data</dfn> is a [=struct=] with the following
+An <dfn for=fencedframetype>automatic beacon data</dfn> is a [=struct=] with the following
 [=struct/items=]:
      
-<dl export dfn-for="automatic beacon data">
+<dl dfn-for="automatic beacon data">
   : <dfn>eventData</dfn>
   :: a [=string=]
 
@@ -809,9 +809,9 @@ A <dfn export for=fencedframetype>destination enum event</dfn> is a [=struct=] w
 
 A <dfn export for=fencedframetype>destination URL event</dfn> is a [=URL=].
 
-An <dfn export for=fencedframetype>automatic beacon event</dfn> is a [=struct=] with the following
+An <dfn for=fencedframetype>automatic beacon event</dfn> is a [=struct=] with the following
 [=struct/items=]:
-<dl export dfn-for="automatic beacon event">
+<dl dfn-for="automatic beacon event">
   : <dfn>type</dfn>
   :: an [=fencedframetype/automatic beacon event type=]
 
@@ -1732,17 +1732,17 @@ traversable=].
        reporter=] with |destination| and an [=fencedframetype/automatic beacon event=] with the
        following [=struct/items=]:
 
-       : [=destination enum event/type=]
+       : [=automatic beacon event/type=]
        :: |eventType|
 
-       : [=destination enum event/data=]
+       : [=automatic beacon event/data=]
        :: |beacon data|'s [=automatic beacon data/eventData=] if |beacon data|'s [=automatic beacon
           data/destinations=] [=list/contains=] |destination|, the empty string otherwise.
 
-       : [=destination enum event/attributionReportingEnabled=]
+       : [=automatic beacon event/attributionReportingEnabled=]
        :: |sourceSnapshotParams|'s [=source snapshot params/attribution reporting enabled=]
 
-       : [=destination enum event/attributionReportingContextOrigin=]
+       : [=automatic beacon event/attributionReportingContextOrigin=]
        :: |sourceSnapshotParams|'s [=source snapshot params/attribution reporting context origin=]
 
   1. If |beacon data|'s [=automatic beacon data/once=] is true, set |config|'s [=fenced frame

--- a/spec.bs
+++ b/spec.bs
@@ -761,6 +761,25 @@ following [=struct/items=]:
   :: a [=boolean=], initially false
 </dl>
 
+The <dfn export for=fencedframetype>valid automatic beacon event types</dfn> are a [=list=] with the
+following [=list/items=]:
+
+« "`reserved.top_navigation_start`", "`reserved.top_navigation_commit`" »
+
+An <dfn export for=fencedframetype>automatic beacon data</dfn> is a [=struct=] with the following
+[=struct/items=]:
+     
+<dl export dfn-for="automatic beacon data">
+  : <dfn>eventData</dfn>
+  :: a [=string=]
+
+  : <dfn>destination</dfn>
+  :: a [=list=] of {{FenceReportingDestination}}s
+
+  : <dfn>once</dfn>
+  :: a [=boolean=]
+</dl>
+
 A <dfn export for=fencedframetype>fenced frame reporter</dfn> is a [=struct=] with the following
 [=struct/items=]:
 <dl export dfn-for="fenced frame reporter">
@@ -768,18 +787,9 @@ A <dfn export for=fencedframetype>fenced frame reporter</dfn> is a [=struct=] wi
   :: a mutable reference to a [=fencedframetype/fenced frame reporting metadata=]
      <span class=XXX>TODO: Handle pointers/references in a more spec-y way</span>
 
-  : <dfn>automatic beacon data</dfn>
-  :: null, or a [=struct=] with the following [=struct/items=]:
-     <dl dfn-for="automatic beacon data">
-       : <dfn>eventData</dfn>
-       :: a [=string=]
-
-       : <dfn>destination</dfn>
-       :: a [=list=] of {{FenceReportingDestination}}s
-
-       : <dfn>once</dfn>
-       :: a [=boolean=]
-     </dl>
+  : <dfn>automatic beacon data map</dfn>
+  :: a [=map=] whose [=map/keys=] are [=strings=] and whose [=map/values=] are null or an
+     [=fencedframetype/automatic beacon data=]
 </dl>
 
 A <dfn export for=fencedframetype>destination enum event</dfn> is a [=struct=] with the following
@@ -830,8 +840,9 @@ A <dfn export for=fencedframetype>destination event</dfn> is either a
        of [=getting supported registrars=] is not [=list/is empty|empty=] and |event|'s
        [=destination enum event/attributionReportingContextOrigin=] [=check if an origin is suitable|is suitable=]:
 
-        1. If |event|'s [=destination enum event/type=] is `"reserved.top_navigation"`,
-           set |attributionReportingEligibility| to "<code>[=eligibility/navigation-source=]</code>".
+        1. If the list of [=fencedframetype/valid automatic beacon event types=] [=list/contains=]
+           |event|'s [=destination enum event/type=], set |attributionReportingEligibility| to
+           "<code>[=eligibility/navigation-source=]</code>".
 
         1. Otherwise, set |attributionReportingEligibility| to "<code>[=eligibility/event-source=]</code>".
 
@@ -1176,8 +1187,8 @@ A <dfn export>fenced frame config instance</dfn> is a [=struct=] with the follow
             :: a reference to |config|'s [=fenced frame config/fenced frame reporting metadata=]'s
                [=fenced frame reporting metadata/value=]
 
-            : [=fenced frame reporter/automatic beacon data=]
-            :: null
+            : [=fenced frame reporter/automatic beacon data map=]
+            :: an empty [=map=]
 
     : [=fenced frame config instance/exfiltration budget metadata reference=]
     ::
@@ -1530,7 +1541,8 @@ Several APIs specific to fenced frames are defined on the {{Fence}} interface.
      {{FenceEvent/eventType}}:
      1. [=exception/Throw=] a {{TypeError}}.
 
-  1. If |event|'s {{FenceEvent/eventType}} is not `"reserved.top_navigation"`, return.
+  1. If [=fencedframetype/valid automatic beacon event types=] does not [=list/contain=] |event|'s
+     {{FenceEvent/eventType}}, return.
 
   1. Let |instance| be [=this=]'s [=relevant global object=]'s [=Window/browsing context=]'s
      [=browsing context/fenced frame config instance=].
@@ -1544,7 +1556,8 @@ Several APIs specific to fenced frames are defined on the {{Fence}} interface.
   1. If |instance|'s [=fenced frame config instance/fenced frame reporter=] is null, then return.
 
   1. Set |instance|'s [=fenced frame config instance/fenced frame reporter=]'s [=fenced frame
-     reporter/automatic beacon data=] to a [=struct=] with the following [=struct/items=]:
+     reporter/automatic beacon data map=][|event|'s {{FenceEvent/eventType}}] to a [=struct=] with
+     the following [=struct/items=]:
 
      : [=automatic beacon data/eventData=]
      :: |event|'s {{FenceEvent/eventData}} if defined, otherwise empty string
@@ -1658,17 +1671,19 @@ table](https://fetch.spec.whatwg.org/#destination-table) to illustrate that <{fe
 A side effect of the fenced boundary model is that ads will lose the ability to know if a click
 resulted in a successful navigation. This is because the page loaded from a top-level [=navigate|
 navigation=] originating from a fenced frame will not be allowed to report to the fenced frame that
-it loaded (through something like <code>window.[=Window/opener=]</code>). Instead, we introduce a
-special event-level [=destination enum event/type|reporting type=], `reserved.top_navigation`, which
-automatically sends an [=report an event|event-level beacon=] when a fenced frame initiates a
-successful [=navigate|navigation=] to a [=top-level traversable=].
+it loaded (through something like <code>window.[=Window/opener=]</code>). Instead, we introduce
+special event-level [=destination enum event/type|reporting type=]s, `reserved.top_navigation_start`
+and `resrved.top_navigation_commit`, which automatically sends an [=report an event|event-level
+beacon=] when a fenced frame initiates a successful [=navigate|navigation=] to a [=top-level
+traversable=].
 
 <div algorithm>
   To <dfn>attempt to send an automatic beacon</dfn> given a [=source snapshot params=]
   |sourceSnapshotParams|, an [=origin=] |sourceOrigin|, a {{Document}} |targetDocument|, and a
   [=string=] |eventType|, run these steps:
 
-  1. [=Assert=]: |eventType| is "`reserved.top_navigation`".
+  1. [=Assert=]: The [=fencedframetype/valid automatic beacon event types=] [=list/contains=]
+     |eventType|.
 
   1. If |targetDocument|'s [=node navigable=]'s [=traversable navigable=] is not a [=top-level
      traversable=], abort these steps.
@@ -1686,7 +1701,7 @@ successful [=navigate|navigation=] to a [=top-level traversable=].
      <{fencedframe}>.
 
   1. Let |beacon data| be |config|'s [=fenced frame config instance/fenced frame reporter=]'s
-     [=fenced frame reporter/automatic beacon data=].
+     [=fenced frame reporter/automatic beacon data map=][|eventType|].
 
   1. Let |event data| be |beacon data|'s [=automatic beacon data/eventData=] if |beacon data| is not
      null, the empty string otherwise.
@@ -1720,8 +1735,8 @@ successful [=navigate|navigation=] to a [=top-level traversable=].
        :: |sourceSnapshotParams|'s [=source snapshot params/attribution reporting context origin=]
 
   1. If |beacon data|'s [=automatic beacon data/once=] is true, set |config|'s [=fenced frame
-      config instance/fenced frame reporter=]'s [=fenced frame reporter/automatic beacon data=] to
-      null.
+      config instance/fenced frame reporter=]'s [=fenced frame reporter/automatic beacon data map=]
+      to null.
 
   <wpt>
     /fenced-frame/automatic-beacon-click-handler.https.html
@@ -1732,13 +1747,21 @@ successful [=navigate|navigation=] to a [=top-level traversable=].
   </wpt>
 </div>
 
-<div algorithm="automatic beacon patch">
+<div algorithm="top_navigation_start beacon patch">
+  Modify [[HTML]]'s [=navigate=] algorithm. Add a new step after step 4 that reads:
+  
+  5. [=attempt to send an automatic beacon=] given <var ignore>sourceDocument</var>, <var
+     ignore>sourceSnapshotParams</var>, <var ignore>navigable</var>’s associated {{Document}}, and
+     "`reserved.top_navigation_start`".
+</div>
+
+<div algorithm="top_navigation_commit beacon patch">
   Modify [[HTML]]'s [=attempt to populate the history entry's document=] algorithm. In step 6,
   substep 11, add a new step after step 5 that reads:
 
   6. if <var ignore>failure</var> is false, then [=attempt to send an automatic beacon=] given <var
      ignore>sourceSnapshotParams</var>, <var ignore>entry</var>'s [=document state=]'s [=document
-     state/initiator origin=], <var ignore>document</var>, and "`reserved.top_navigation`".
+     state/initiator origin=], <var ignore>document</var>, and "`reserved.top_navigation_commit`".
 </div>
 
 <h2 id=html-integration>HTML Integration</h2>

--- a/spec.bs
+++ b/spec.bs
@@ -848,11 +848,6 @@ A <dfn export for=fencedframetype>destination event</dfn> is either a
      1. Let |destination map| be |destination info|'s
         [=reporting destination info/reporting url map=].
 
-     1. If |event| is a [=fencedframetype/destination enum event=], then let |eventType| be
-        |event|'s [=destination enum event/type=].
-
-        Otherwise, let |eventType| be |event|'s [=automatic beacon event/type=].
-
      1. Let |eventType| be either |event|'s [=destination enum event/type|destination type=], or
         [=automatic beacon event/type|automatic type=], depending on which variant |event| is.
 

--- a/spec.bs
+++ b/spec.bs
@@ -1556,8 +1556,8 @@ Several APIs specific to fenced frames are defined on the {{Fence}} interface.
   1. If |instance|'s [=fenced frame config instance/fenced frame reporter=] is null, then return.
 
   1. Set |instance|'s [=fenced frame config instance/fenced frame reporter=]'s [=fenced frame
-     reporter/automatic beacon data map=][|event|'s {{FenceEvent/eventType}}] to a [=struct=] with
-     the following [=struct/items=]:
+     reporter/automatic beacon data map=][|event|'s {{FenceEvent/eventType}}] to an
+     [=fencedframetype/automatic beacon data=] with the following [=struct/items=]:
 
      : [=automatic beacon data/eventData=]
      :: |event|'s {{FenceEvent/eventData}} if defined, otherwise empty string
@@ -1730,8 +1730,8 @@ traversable=].
        :: |sourceSnapshotParams|'s [=source snapshot params/attribution reporting context origin=]
 
   1. If |beacon data|'s [=automatic beacon data/once=] is true, set |config|'s [=fenced frame
-      config instance/fenced frame reporter=]'s [=fenced frame reporter/automatic beacon data map=]
-      to null.
+      config instance/fenced frame reporter=]'s [=fenced frame reporter/automatic beacon data
+      map=][|eventType|] to null.
 
   <wpt>
     /fenced-frame/automatic-beacon-click-handler.https.html
@@ -2417,7 +2417,7 @@ CORP violation report=] algorithm, as leaving it unfenced may cause a privacy le
   Note: The [=source snapshot params/initiator fenced frame config instance=] is the [=fenced frame
   config instance=] that's loaded into a navigation initiator's [=browsing context=], if any exists.
   It is used by the [=attempt to send an automatic beacon=] algorithm to retrieve the [=fenced frame
-  reporter/automatic beacon data=] to be sent out if the <{fencedframe}>-initiated navigation
+  reporter/automatic beacon data map=] to be sent out if the <{fencedframe}>-initiated navigation
   succeeds. The [=source snapshot params/target fenced frame config=] on the other hand, is the
   non-[=instantiate a config|instantiated=] [=fenced frame config=] that will be loaded into a a
   <{fencedframe}> element for navigations targeting fenced frames. These fields do not interact

--- a/spec.bs
+++ b/spec.bs
@@ -1756,6 +1756,7 @@ event|event-level beacon=] when a fenced frame initiates a successful [=navigate
       map=][|eventType|] to null.
 
   <wpt>
+    /fenced-frame/automatic-beacon-anchor-click-handler.https.html
     /fenced-frame/automatic-beacon-click-handler.https.html
     /fenced-frame/automatic-beacon-two-events-clear.https.html
     /fenced-frame/automatic-beacon-two-events-persist.https.html

--- a/spec.bs
+++ b/spec.bs
@@ -761,10 +761,16 @@ following [=struct/items=]:
   :: a [=boolean=], initially false
 </dl>
 
-The <dfn export for=fencedframetype>valid automatic beacon event types</dfn> are a [=list=] with the
-following [=list/items=]:
+An <dfn export for=fencedframetype>automatic beacon event type</dfn> is one of the following:
+<dl export dfn-for="automatic beacon event type">
+  : "<dfn>reserved.top_navigation_start</dfn>"
+  :: Sent at the beginning of a top-level [=navigate|navigation=]
 
-« "`reserved.top_navigation_start`", "`reserved.top_navigation_commit`" »
+  : "<dfn>reserved.top_navigation_commit</dfn>"
+  :: Sent while [=attempt to populate the history entry's document|attempting to populate the
+     history entry's document=] for a top-level navigation
+</dl>
+
 
 An <dfn export for=fencedframetype>automatic beacon data</dfn> is a [=struct=] with the following
 [=struct/items=]:
@@ -788,8 +794,8 @@ A <dfn export for=fencedframetype>fenced frame reporter</dfn> is a [=struct=] wi
      <span class=XXX>TODO: Handle pointers/references in a more spec-y way</span>
 
   : <dfn>automatic beacon data map</dfn>
-  :: a [=map=] whose [=map/keys=] are [=strings=] and whose [=map/values=] are null or an
-     [=fencedframetype/automatic beacon data=]
+  :: a [=map=] whose [=map/keys=] are [=fencedframetype/automatic beacon event type=]s and whose
+     [=map/values=] are null or an [=fencedframetype/automatic beacon data=]
 </dl>
 
 A <dfn export for=fencedframetype>destination enum event</dfn> is a [=struct=] with the following
@@ -810,8 +816,26 @@ A <dfn export for=fencedframetype>destination enum event</dfn> is a [=struct=] w
 
 A <dfn export for=fencedframetype>destination URL event</dfn> is a [=URL=].
 
+An <dfn export for=fencedframetype>automatic beacon event</dfn> is a [=struct=] with the following
+[=struct/items=]:
+<dl export dfn-for="automatic beacon event">
+  : <dfn>type</dfn>
+  :: an [=fencedframetype/automatic beacon event type=]
+
+  : <dfn>data</dfn>
+  :: a [=string=]
+
+  : <dfn>attributionReportingEnabled</dfn>
+  :: a [=boolean=]
+
+  : <dfn>attributionReportingContextOrigin</dfn>
+  :: an [=origin=]
+</dl>
+
+
 A <dfn export for=fencedframetype>destination event</dfn> is either a
-[=fencedframetype/destination enum event=] or a [=fencedframetype/destination URL event=].
+[=fencedframetype/destination enum event=], a [=fencedframetype/destination URL event=], or a
+[=fencedframetype/automatic beacon event=].
 
 <div algorithm>
   In order to <dfn>send a beacon</dfn> with a [=fencedframetype/reporting destination info=]
@@ -825,12 +849,16 @@ A <dfn export for=fencedframetype>destination event</dfn> is either a
 
   1. Let |useParallelQueue| be false.
 
-  1. If |event| is a [=fencedframetype/destination enum event=], then:
+  1. If |event| is either a [=fencedframetype/destination enum event=] or an
+     [=fencedframetype/automatic beacon event=], then:
 
      1. Let |destination map| be |destination info|'s
         [=reporting destination info/reporting url map=].
 
-     1. Let |eventType| be |event|'s [=destination enum event/type=].
+     1. If |event| is a [=fencedframetype/destination enum event=], then let |eventType| be
+        |event|'s [=destination enum event/type=].
+
+        Otherwise, let |eventType| be |event|'s [=automatic beacon event/type=].
 
      1. If |destination map|[|eventType|] does not [=map/exist=], return.
 
@@ -840,8 +868,8 @@ A <dfn export for=fencedframetype>destination event</dfn> is either a
        of [=getting supported registrars=] is not [=list/is empty|empty=] and |event|'s
        [=destination enum event/attributionReportingContextOrigin=] [=check if an origin is suitable|is suitable=]:
 
-        1. If the list of [=fencedframetype/valid automatic beacon event types=] [=list/contains=]
-           |event|'s [=destination enum event/type=], set |attributionReportingEligibility| to
+        1. If |event|'s {{FenceEvent/eventType}} matches one of the [=fencedframetype/automatic
+           beacon event type=] values, set |attributionReportingEligibility| to
            "<code>[=eligibility/navigation-source=]</code>".
 
         1. Otherwise, set |attributionReportingEligibility| to "<code>[=eligibility/event-source=]</code>".
@@ -1541,8 +1569,8 @@ Several APIs specific to fenced frames are defined on the {{Fence}} interface.
      {{FenceEvent/eventType}}:
      1. [=exception/Throw=] a {{TypeError}}.
 
-  1. If [=fencedframetype/valid automatic beacon event types=] does not [=list/contain=] |event|'s
-     {{FenceEvent/eventType}}, return.
+  1. If |event|'s {{FenceEvent/eventType}} does not match one of the [=fencedframetype/automatic
+     beacon event type=] values, return.
 
   1. Let |instance| be [=this=]'s [=relevant global object=]'s [=Window/browsing context=]'s
      [=browsing context/fenced frame config instance=].
@@ -1679,11 +1707,8 @@ traversable=].
 
 <div algorithm>
   To <dfn>attempt to send an automatic beacon</dfn> given a [=source snapshot params=]
-  |sourceSnapshotParams|, an [=origin=] |sourceOrigin|, a {{Document}} |targetDocument|, and a
-  [=string=] |eventType|, run these steps:
-
-  1. [=Assert=]: The [=fencedframetype/valid automatic beacon event types=] [=list/contains=]
-     |eventType|.
+  |sourceSnapshotParams|, an [=origin=] |sourceOrigin|, a {{Document}} |targetDocument|, and an
+  [=fencedframetype/automatic beacon event type=] |eventType|, run these steps:
 
   1. If |targetDocument|'s [=node navigable=]'s [=traversable navigable=] is not a [=top-level
      traversable=], abort these steps.
@@ -1713,7 +1738,7 @@ traversable=].
      [=fencedframetype/fenced frame reporting map=]'s [=map/keys=]:
 
     1. Run [=report an event=] using |config|'s [=fenced frame config instance/fenced frame
-       reporter=] with |destination| and a [=fencedframetype/destination enum event=] with the
+       reporter=] with |destination| and an [=fencedframetype/automatic beacon event=] with the
        following [=struct/items=]:
 
        : [=destination enum event/type=]
@@ -1748,7 +1773,7 @@ traversable=].
   
   5. [=Attempt to send an automatic beacon=] given <var ignore>sourceSnapshotParams</var>, <var
      ignore>initiatorOriginSnapshot</var>, <var ignore>navigable</var>’s associated {{Document}},
-     and "`reserved.top_navigation_start`".
+     and "[=automatic beacon event type/reserved.top_navigation_start=]".
 </div>
 
 <div algorithm="top_navigation_commit beacon patch">
@@ -1757,7 +1782,8 @@ traversable=].
 
   6. If <var ignore>failure</var> is false, then [=attempt to send an automatic beacon=] given <var
      ignore>sourceSnapshotParams</var>, <var ignore>entry</var>'s [=document state=]'s [=document
-     state/initiator origin=], <var ignore>document</var>, and "`reserved.top_navigation_commit`".
+     state/initiator origin=], <var ignore>document</var>, and "[=automatic beacon event
+     type/reserved.top_navigation_commit=]".
 </div>
 
 <h2 id=html-integration>HTML Integration</h2>

--- a/spec.bs
+++ b/spec.bs
@@ -853,6 +853,9 @@ A <dfn export for=fencedframetype>destination event</dfn> is either a
 
         Otherwise, let |eventType| be |event|'s [=automatic beacon event/type=].
 
+     1. Let |eventType| be either |event|'s [=destination enum event/type|destination type=], or
+        [=automatic beacon event/type|automatic type=], depending on which variant |event| is.
+
      1. If |destination map|[|eventType|] does not [=map/exist=], return.
 
      1. Set |destination url| to |destination map|[|eventType|].

--- a/spec.bs
+++ b/spec.bs
@@ -761,16 +761,9 @@ following [=struct/items=]:
   :: a [=boolean=], initially false
 </dl>
 
-An <dfn export for=fencedframetype>automatic beacon event type</dfn> is one of the following:
-<dl export dfn-for="automatic beacon event type">
-  : "<dfn>reserved.top_navigation_start</dfn>"
-  :: Sent at the beginning of a top-level [=navigate|navigation=]
-
-  : "<dfn>reserved.top_navigation_commit</dfn>"
-  :: Sent while [=attempt to populate the history entry's document|attempting to populate the
-     history entry's document=] for a top-level navigation
-</dl>
-
+An <dfn export for=fencedframetype>automatic beacon event type</dfn> is either "<dfn export
+for="automatic beacon event type">`reserved.top_navigation_start`</dfn>" or "<dfn export
+for="automatic beacon event type">`reserved.top_navigation_commit`</dfn>".
 
 An <dfn export for=fencedframetype>automatic beacon data</dfn> is a [=struct=] with the following
 [=struct/items=]:


### PR DESCRIPTION
This PR does a few things to allow the new automatic beacon types:

- ~~Creates a new "valid automatic beacon event types" list that contains the start and commit beacon types.~~
-  Creates a new implicit enumerated type for the automatic beacon event types. This contains the start and commit beacon types.
- Creates a new "automatic beacon event" to be used for automatic beacons instead of "destination enum event", which contains the aforementioned implicit enumerated event type.
- Splits out automatic beacon data into its own struct.
- Turns the fenced frame reporter's automatic beacon data into a mapping to match the implementation.
- Passes "reserved.top_navigation_commit" as a parameter when calling the automatic beacon algorithm from its existing place at navigation commit.
- Also calls the automatic beacon algorithm at navigation start passing in "reserved.top_navigation_start".
- Removes "reserved.top_navigation".


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/WICG/fenced-frame/pull/130.html" title="Last updated on Nov 7, 2023, 4:43 PM UTC (e922439)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/fenced-frame/130/dc24e72...e922439.html" title="Last updated on Nov 7, 2023, 4:43 PM UTC (e922439)">Diff</a>