### PR TITLE
Unexport destination events

### DIFF
--- a/spec.bs
+++ b/spec.bs
@@ -782,9 +782,9 @@ A <dfn export for=fencedframetype>fenced frame reporter</dfn> is a [=struct=] wi
      </dl>
 </dl>
 
-A <dfn export for=fencedframetype>destination enum event</dfn> is a [=struct=] with the following
+A <dfn for=fencedframetype>destination enum event</dfn> is a [=struct=] with the following
 [=struct/items=]:
-<dl export dfn-for="destination enum event">
+<dl dfn-for="destination enum event">
   : <dfn>type</dfn>
   :: a [=string=]
 
@@ -798,9 +798,9 @@ A <dfn export for=fencedframetype>destination enum event</dfn> is a [=struct=] w
   :: an [=origin=]
 </dl>
 
-A <dfn export for=fencedframetype>destination URL event</dfn> is a [=URL=].
+A <dfn for=fencedframetype>destination URL event</dfn> is a [=URL=].
 
-A <dfn export for=fencedframetype>destination event</dfn> is either a
+A <dfn for=fencedframetype>destination event</dfn> is either a
 [=fencedframetype/destination enum event=] or a [=fencedframetype/destination URL event=].
 
 <div algorithm>


### PR DESCRIPTION
These are only being used inside the fenced frame spec, so they can be safely unexported.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/WICG/fenced-frame/pull/132.html" title="Last updated on Oct 27, 2023, 6:15 PM UTC (1d3c703)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/fenced-frame/132/94b48b1...1d3c703.html" title="Last updated on Oct 27, 2023, 6:15 PM UTC (1d3c703)">Diff</a>