### PR TITLE
Prevent reserved beacons from being sent manually.

### DIFF
--- a/spec.bs
+++ b/spec.bs
@@ -761,7 +761,7 @@ following [=struct/items=]:
   :: a [=boolean=], initially false
 </dl>
 
-An <dfn for=fencedframetype>automatic beacon event type</dfn> is either "<dfn
+An <dfn export for=fencedframetype>automatic beacon event type</dfn> is either "<dfn
 for="automatic beacon event type">`reserved.top_navigation_start`</dfn>", "<dfn
 for="automatic beacon event type">`reserved.top_navigation_commit`</dfn>", or "<dfn
 for="automatic beacon event type">`reserved.top_navigation`</dfn>".

--- a/spec.bs
+++ b/spec.bs
@@ -1006,6 +1006,8 @@ A <dfn for=fencedframetype>destination event</dfn> is either a
   In order to <dfn>report a private aggregation event</dfn> using a [=fencedframetype/fenced frame
   reporter=] |reporter| with a [=string=] |event|, run these steps:
 
+  1. If |event|'s {{FenceEvent/eventType}} [=string/starts with=] "`reserved.`", then return.
+
   1. |reporter| |event| <span class=XXX>TODO: Fill this in</span>
 </div>
 
@@ -1517,6 +1519,8 @@ Several APIs specific to fenced frames are defined on the {{Fence}} interface.
      [=fenced frame config instance/fenced frame reporter=] with |event|.
 
   1. If |event| is a {{FenceEvent}}:
+
+     1. If |event|'s {{FenceEvent/eventType}} [=string/starts with=] "`reserved.`", then return.
 
      1. If |event| has a {{FenceEvent/destinationURL}}:
         1. If |event| has a {{FenceEvent/destination}} or a {{FenceEvent/eventType}} or a


### PR DESCRIPTION
Reporting an event through the `window.fence.reportEvent()` call should not be allowed to work if it's passed in a "reserved." event type.

This PR also exports `automatic beacon event type`, which will be used by the TURTLEDOVE spec for a similar patch to `registerAdBeacon()`.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/WICG/fenced-frame/pull/134.html" title="Last updated on Dec 18, 2023, 7:24 PM UTC (b94150e)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/fenced-frame/134/79fad8a...b94150e.html" title="Last updated on Dec 18, 2023, 7:24 PM UTC (b94150e)">Diff</a>