### PR TITLE
Add ad component event reporting algorithms.

### DIFF
--- a/spec.bs
+++ b/spec.bs
@@ -1604,7 +1604,7 @@ Several APIs specific to fenced frames are defined on the {{Fence}} interface.
      [=fencedframetype/automatic beacon data=] with the following [=struct/items=]:
 
      : [=automatic beacon data/eventData=]
-     :: |event|'s {{FenceEvent/eventData}} if defined, otherwise empty string
+     :: If |instance|'s [=fenced frame config instance/is ad component=] is false, then |event|'s {{FenceEvent/eventData}}. Otherwise, the empty string.
 
      : [=automatic beacon data/destination=]
      :: |event|'s {{FenceEvent/destination}}

--- a/spec.bs
+++ b/spec.bs
@@ -1764,7 +1764,8 @@ event|event-level beacon=] when a fenced frame initiates a successful [=navigate
 
        : [=automatic beacon event/data=]
        :: |beacon data|'s [=automatic beacon data/eventData=] if |beacon data|'s [=automatic beacon
-          data/destinations=] [=list/contains=] |destination|, the empty string otherwise.
+          data/destinations=] [=list/contains=] |destination| and |config|'s [=fenced frame config
+          instance/is ad component=] is false, the empty string otherwise.
 
        : [=automatic beacon event/attributionReportingEnabled=]
        :: |sourceSnapshotParams|'s [=source snapshot params/attribution reporting enabled=]

--- a/spec.bs
+++ b/spec.bs
@@ -1604,7 +1604,8 @@ Several APIs specific to fenced frames are defined on the {{Fence}} interface.
      [=fencedframetype/automatic beacon data=] with the following [=struct/items=]:
 
      : [=automatic beacon data/eventData=]
-     :: |event|'s {{FenceEvent/eventData}} if defined and |instance|'s [=fenced frame config instance/is ad component=] is false, otherwise empty [=string=].
+     :: |event|'s {{FenceEvent/eventData}} if defined and |instance|'s [=fenced frame config
+     instance/is ad component=] is false, otherwise empty [=string=].
 
      : [=automatic beacon data/destination=]
      :: |event|'s {{FenceEvent/destination}}

--- a/spec.bs
+++ b/spec.bs
@@ -1603,8 +1603,8 @@ Several APIs specific to fenced frames are defined on the {{Fence}} interface.
      reporter/automatic beacon data map=][|event|'s {{FenceEvent/eventType}}] to an
      [=fencedframetype/automatic beacon data=] with the following [=struct/items=]:
 
-     : [=automatic beacon data/eventData=]
-     :: If |instance|'s [=fenced frame config instance/is ad component=] is false, then |event|'s {{FenceEvent/eventData}}. Otherwise, the empty [=string=].
+     : [=automatic beacon data/eventData=] 
+     :: |event|'s {{FenceEvent/eventData}} if defined and |instance|'s [=fenced frame config instance/is ad component=] is false, otherwise empty [=string=].
 
      : [=automatic beacon data/destination=]
      :: |event|'s {{FenceEvent/destination}}

--- a/spec.bs
+++ b/spec.bs
@@ -1603,7 +1603,7 @@ Several APIs specific to fenced frames are defined on the {{Fence}} interface.
      reporter/automatic beacon data map=][|event|'s {{FenceEvent/eventType}}] to an
      [=fencedframetype/automatic beacon data=] with the following [=struct/items=]:
 
-     : [=automatic beacon data/eventData=] 
+     : [=automatic beacon data/eventData=]
      :: |event|'s {{FenceEvent/eventData}} if defined and |instance|'s [=fenced frame config instance/is ad component=] is false, otherwise empty [=string=].
 
      : [=automatic beacon data/destination=]

--- a/spec.bs
+++ b/spec.bs
@@ -1604,7 +1604,7 @@ Several APIs specific to fenced frames are defined on the {{Fence}} interface.
      [=fencedframetype/automatic beacon data=] with the following [=struct/items=]:
 
      : [=automatic beacon data/eventData=]
-     :: If |instance|'s [=fenced frame config instance/is ad component=] is false, then |event|'s {{FenceEvent/eventData}}. Otherwise, the empty string.
+     :: If |instance|'s [=fenced frame config instance/is ad component=] is false, then |event|'s {{FenceEvent/eventData}}. Otherwise, the empty [=string=].
 
      : [=automatic beacon data/destination=]
      :: |event|'s {{FenceEvent/destination}}

--- a/spec.bs
+++ b/spec.bs
@@ -1605,7 +1605,7 @@ Several APIs specific to fenced frames are defined on the {{Fence}} interface.
 
      : [=automatic beacon data/eventData=]
      :: |event|'s {{FenceEvent/eventData}} if defined and |instance|'s [=fenced frame config
-     instance/is ad component=] is false, otherwise empty [=string=].
+        instance/is ad component=] is false, otherwise empty [=string=].
 
      : [=automatic beacon data/destination=]
      :: |event|'s {{FenceEvent/destination}}

--- a/spec.bs
+++ b/spec.bs
@@ -598,6 +598,8 @@ follows:
   1. [=map/iterate|For each=] |urn| → |config| of |nestedConfigs|:
 
     1. [=map/Set=] |nestedMapping|[|urn|] to |config|.
+    
+    1. Set |nestedMapping|[|urn|]'s [=fenced frame config/is ad component=] to true.
 </div>
 
 <div algorithm>
@@ -1506,6 +1508,8 @@ Several APIs specific to fenced frames are defined on the {{Fence}} interface.
      [=browsing context/fenced frame config instance=].
 
   1. If |instance| is null, then return.
+  
+  1. If |instance|'s [=fenced frame config instance/is ad component=] is true, then return.
 
   1. If the [=relevant settings object=]'s [=environment settings object/origin=] and |instance|'s
      [=fenced frame config instance/mapped url=]'s [=url/origin=] are not [=same origin=], then


### PR DESCRIPTION
This PR specs the event reporting algorithms for ad component frames, according to the [Protected Audience explainer](https://github.com/WICG/turtledove/blob/main/Fenced_Frames_Ads_Reporting.md#design-1).


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/xiaochen-z/fenced-frame/pull/135.html" title="Last updated on Dec 18, 2023, 9:10 PM UTC (63cf39f)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/fenced-frame/135/79fad8a...xiaochen-z:63cf39f.html" title="Last updated on Dec 18, 2023, 9:10 PM UTC (63cf39f)">Diff</a>