### PR TITLE
Fix failing build caused by stale reference

### DIFF
--- a/spec.bs
+++ b/spec.bs
@@ -1773,9 +1773,8 @@ event|event-level beacon=] when a fenced frame initiates a successful [=navigate
        : [=automatic beacon event/attributionReportingContextOrigin=]
        :: |sourceSnapshotParams|'s [=source snapshot params/attribution reporting context origin=]
 
-  1. If |beacon data|'s [=automatic beacon data/once=] is true, set |config|'s [=fenced frame
-      config instance/fenced frame reporter=]'s [=fenced frame reporter/automatic beacon data
-      map=][|eventType|] to null.
+  1. If |beacon data|'s [=automatic beacon data/once=] is true, set |sourceSnapshotParams|'s
+     [=source snapshot params/automatic beacon data map=][|eventType|] to null.
 
   <wpt>
     /fenced-frame/automatic-beacon-anchor-click-handler.https.html


### PR DESCRIPTION
This updates the line that clears out automatic beacon data whose `once=True` to use the new automatic beacon data map that was added in https://github.com/WICG/fenced-frame/pull/133.

One concern I have about this is whether or not the [get the automatic beacon data mapping to use](https://wicg.github.io/fenced-frame/#get-the-automatic-beacon-data-mapping-to-use) algorithm is building a map of references to or copies of the original mapping. If it's the latter, then we'll need to do further refactoring to make sure that the things in the various mappings can be modified by the "maybe send automatic beacon" algorithm.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/WICG/fenced-frame/pull/139.html" title="Last updated on Jan 18, 2024, 11:31 PM UTC (53608f0)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/fenced-frame/139/cce562b...53608f0.html" title="Last updated on Jan 18, 2024, 11:31 PM UTC (53608f0)">Diff</a>