### PR TITLE
Ensure the automatic beacon data map is a reference

### DIFF
--- a/spec.bs
+++ b/spec.bs
@@ -2521,6 +2521,8 @@ CORP violation report=] algorithm, as leaving it unfenced may cause a privacy le
 <div algorithm>
   To <dfn>get the automatic beacon data mapping to use</dfn> given a {{Document}} |sourceDocument|:
   
+  1. [=Assert=] these steps are running on |sourceDocument|'s [=event loop=].
+
   1. Let |automatic beacon data map| be a new empty [=Document/automatic beacon data map=].
   
   1. Let |current navigable| be |sourceDocument|'s [=node navigable=].
@@ -2540,6 +2542,11 @@ CORP violation report=] algorithm, as leaving it unfenced may cause a privacy le
     1. Set |current navigable| to |current navigable|'s [=navigable/parent=].
 
   1. Return |automatic beacon data map|.
+
+  Note: The returned map is meant to hold references to the original {{Document}}'s
+  [=Document/automatic beacon data map=]s that were used to build |automatic beacon data map|. These
+  are later modified in [=attempt to send an automatic beacon=] to clear out any beacon data with
+  [=automatic beacon data/once=] set to true.
 </div>
 
 <div algorithm=snapshot-source-snapshot-params>


### PR DESCRIPTION
The automatic beacon algorithm uses an automatic beacon data map that is built off of the data maps in the initiator frame's ancestors. This PR makes more clear that the data map should be stored as references to the original automatic beacon data maps, since it is needed to make modifications while running the automatic beacon algorithm.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/WICG/fenced-frame/pull/141.html" title="Last updated on Jan 22, 2024, 9:21 PM UTC (d24816e)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/fenced-frame/141/d6a5a54...d24816e.html" title="Last updated on Jan 22, 2024, 9:21 PM UTC (d24816e)">Diff</a>