### PR TITLE
Add a non-normative use cases section

### DIFF
--- a/spec.bs
+++ b/spec.bs
@@ -655,22 +655,24 @@ An ad auction API runs an auction and determines a winning ad. Details about the
 hidden from the embedder, and the embedding context cannot be allowed to influence the environment
 of the <{fencedframe}>. Either of those would allow for information to flow across the fenced frame
 boundary, which can allow for colluding parties to join cross-site data and build a profile on the
-user. To prevent that, the ad auction API constructs a [=fenced frame config=] whose underlying [=URL=] is
-opaque to the embedding context. The [=fenced frame config=] is also constructed with restrictions
-on what the [=fenced frame config/container size=] and [=fenced frame config/content size=] of the
-frame must be and what the [=fenced frame config/effective enabled permissions|permissions policy=]
-of the frame must be, as those can be used as fingerprinting vectors.
+user. To prevent that, the ad auction API constructs a [=fenced frame config=] whose underlying
+[=fenced frame config/mapped url|URL=] is opaque to the embedding context. The [=fenced frame
+config=] is also constructed with restrictions on what the [=fenced frame config/container size=]
+and [=fenced frame config/content size=] of the frame must be and what the [=fenced frame
+config/effective enabled permissions|permissions policy=] of the frame must be, as those can be used
+as fingerprinting vectors.
 
 Displaying a personalized payment button:
 
-An e-commerce site embeds a <{fencedframe}> that has a "Pay now" button. This button includes the
-last 4 digits of the user's credit card number as is saved with the e-commerce platform. At first,
-the {{Document}} hosted in the <{fencedframe}> has no access to the data from the e-commerce
-platform, so information can flow in and out without compromising user privacy. Because of that, the
-fenced frame can be constructed directly from the web platform using the {{FencedFrameConfig}}
-constructor without compromising privacy. The {{Document}} can only access that credit card data once it turns off all network
+An e-commerce site embeds a <{fencedframe}> that has a "Pay now" button. At first, the {{Document}}
+hosted in the <{fencedframe}> has no 1p cookie/storage access, so information can freely flow in and
+out without risk of cross-site data joining. Because of that, the fenced frame can be constructed
+directly from the web platform using the {{FencedFrameConfig}} constructor without compromising
+privacy. The button at this point has no personalized data in it since it can't access the credit
+card data yet. The {{Document}} can only read that credit card data once it turns off all network
 access, preventing the data from flowing out of the fenced frame and preventing it from being joined
-with cross-site data to build a user profile.
+with cross-site data to build a user profile. Once it does that, the button will then display the
+last 4 digits of the user's credit card number as is saved with the e-commerce platform.
 
 <h4 id=fenced-frame-config-struct>The [=fenced frame config=] [=struct=]</h4>
 

--- a/spec.bs
+++ b/spec.bs
@@ -655,7 +655,7 @@ An ad auction API runs an auction and determines a winning ad. Details about the
 hidden from the embedder, and the embedding context cannot be allowed to influence the environment
 of the <{fencedframe}>. Either of those would allow for information to flow across the fenced frame
 boundary, which can allow for colluding parties to join cross-site data and build a profile on the
-user. To prevent that, the API constructs a [=fenced frame config=] whose underlying [=URL=] is
+user. To prevent that, the ad auction API constructs a [=fenced frame config=] whose underlying [=URL=] is
 opaque to the embedding context. The [=fenced frame config=] is also constructed with restrictions
 on what the [=fenced frame config/container size=] and [=fenced frame config/content size=] of the
 frame must be and what the [=fenced frame config/effective enabled permissions|permissions policy=]

--- a/spec.bs
+++ b/spec.bs
@@ -251,6 +251,9 @@ spec: attribution-reporting; urlPrefix: https://wicg.github.io/attribution-repor
       text: event-source; url: eligibility-event-source
       text: navigation-source; url: eligibility-navigation-source
       text: unset; url: eligibility-unset
+spec: turtledove; urlPrefix: https://wicg.github.io/turtledove/
+  type: dfn
+    text: construct a pending fenced frame config; url: construct-a-pending-fenced-frame-config
 </pre>
 
 <style>
@@ -652,27 +655,30 @@ Each time a <{fencedframe}> navigates to a [=fenced frame config=], it is instan
 Rendering an ad created through an ad auction:
 
 An ad auction API runs an auction and determines a winning ad. Details about the winning ad must be
-hidden from the embedder, and the embedding context cannot be allowed to influence the environment
-of the <{fencedframe}>. Either of those would allow for information to flow across the fenced frame
+hidden from the embedder, and the embedding context is not allowed to influence the environment of
+the <{fencedframe}>. Either of those would allow for information to flow across the fenced frame
 boundary, which can allow for colluding parties to join cross-site data and build a profile on the
-user. To prevent that, the ad auction API constructs a [=fenced frame config=] whose underlying
-[=fenced frame config/mapped url|URL=] is opaque to the embedding context. The [=fenced frame
-config=] is also constructed with restrictions on what the [=fenced frame config/container size=]
-and [=fenced frame config/content size=] of the frame must be and what the [=fenced frame
-config/effective enabled permissions|permissions policy=] of the frame must be, as those can be used
-as fingerprinting vectors.
+user. To prevent that, the ad auction API [=construct a pending fenced frame config|constructs=] a
+[=fenced frame config=] whose underlying [=fenced frame config/mapped url|URL=] is opaque to the
+embedding context. The [=fenced frame config=] is also constructed with restrictions on what the
+[=fenced frame config/container size=] and [=fenced frame config/content size=] of the frame must be
+and what the [=fenced frame config/effective enabled permissions|permissions policy=] of the frame
+must be, as those can be used as fingerprinting vectors.
 
 Displaying a personalized payment button:
 
-An e-commerce site embeds a <{fencedframe}> that has a "Pay now" button. At first, the {{Document}}
-hosted in the <{fencedframe}> has no 1p cookie/storage access, so information can freely flow in and
-out without risk of cross-site data joining. Because of that, the fenced frame can be constructed
-directly from the web platform using the {{FencedFrameConfig}} constructor without compromising
-privacy. The button at this point has no personalized data in it since it can't access the credit
-card data yet. The {{Document}} can only read that credit card data once it turns off all network
-access, preventing the data from flowing out of the fenced frame and preventing it from being joined
-with cross-site data to build a user profile. Once it does that, the button will then display the
-last 4 digits of the user's credit card number as is saved with the e-commerce platform.
+An e-commerce site embeds a <{fencedframe}> that has a "Pay now" button. The e-commerce site stores
+information about the user's credit card on the browser as first-party storage. At first, the
+{{Document}} hosted in the <{fencedframe}> has no first-party cookie/storage access, so information
+can freely flow in and out without risk of the credit card information being joined with cross-site
+data. Because of that, the fenced frame can be constructed directly from the web platform using the
+{{FencedFrameConfig}} constructor without compromising privacy. The button at this point has no
+personalized data in it since it can't access the credit card data yet. The {{Document}} can only
+read that credit card data once it turns off all network access, preventing the data from flowing
+out of the fenced frame and preventing it from being joined with cross-site data to build a user
+profile. Once it does that, the button will then display the last 4 digits of the user's credit card
+number, as it is saved in the browser, inside the first-party storage partition for the ecommerce
+platform's origin.
 
 <h4 id=fenced-frame-config-struct>The [=fenced frame config=] [=struct=]</h4>
 

--- a/spec.bs
+++ b/spec.bs
@@ -653,7 +653,7 @@ Rendering an ad created through an ad auction:
 
 An ad auction API runs an auction and determines a winning ad. Details about the winning ad must be
 hidden from the embedder, and the embedding context cannot be allowed to influence the environment
-of the <{fencedframe}>. Either of those will allow for information to flow across the fenced frame
+of the <{fencedframe}>. Either of those would allow for information to flow across the fenced frame
 boundary, which can allow for colluding parties to join cross-site data and build a profile on the
 user. To prevent that, the API constructs a [=fenced frame config=] whose underlying [=URL=] is
 opaque to the embedding context. The [=fenced frame config=] is also constructed with restrictions

--- a/spec.bs
+++ b/spec.bs
@@ -647,6 +647,31 @@ Each time a <{fencedframe}> navigates to a [=fenced frame config=], it is instan
 [=fenced frame config instance=], which governs the particular [=browsing context group=] inside the
 [=fenced navigable container/fenced navigable=].
 
+<h4 id=fenced-frame-config-use-cases>Use cases</h4>
+
+Rendering an ad created through an ad auction:
+
+An ad auction API runs an auction and determines a winning ad. Details about the winning ad must be
+hidden from the embedder, and the embedding context cannot be allowed to influence the environment
+of the <{fencedframe}>. Either of those will allow for information to flow across the fenced frame
+boundary, which can allow for colluding parties to join cross-site data and build a profile on the
+user. To prevent that, the API constructs a [=fenced frame config=] whose underlying [=URL=] is
+opaque to the embedding context. The [=fenced frame config=] is also constructed with restrictions
+on what the [=fenced frame config/container size=] and [=fenced frame config/content size=] of the
+frame must be and what the [=fenced frame config/effective enabled permissions|permissions policy=]
+of the frame must be, as those can be used as fingerprinting vectors.
+
+Displaying a personalized payment button:
+
+An e-commerce site embeds a <{fencedframe}> that has a "Pay now" button. This button includes the
+last 4 digits of the user's credit card number as is saved with the e-commerce platform. At first,
+the {{Document}} hosted in the <{fencedframe}> has no access to the data from the e-commerce
+platform, so information can flow in and out without compromising user privacy. Because of that, the
+fenced frame is constructed directly from the web platform using the {{FencedFrameConfig}}
+constructor. The {{Document}} can only access that credit card data once it turns off all network
+access, preventing the data from flowing out of the fenced frame and preventing it from being joined
+with cross-site data to build a user profile.
+
 <h4 id=fenced-frame-config-struct>The [=fenced frame config=] [=struct=]</h4>
 
 We now establish some preliminary types:

--- a/spec.bs
+++ b/spec.bs
@@ -668,7 +668,7 @@ last 4 digits of the user's credit card number as is saved with the e-commerce p
 the {{Document}} hosted in the <{fencedframe}> has no access to the data from the e-commerce
 platform, so information can flow in and out without compromising user privacy. Because of that, the
 fenced frame can be constructed directly from the web platform using the {{FencedFrameConfig}}
-constructor. The {{Document}} can only access that credit card data once it turns off all network
+constructor without compromising privacy. The {{Document}} can only access that credit card data once it turns off all network
 access, preventing the data from flowing out of the fenced frame and preventing it from being joined
 with cross-site data to build a user profile.
 

--- a/spec.bs
+++ b/spec.bs
@@ -667,7 +667,7 @@ An e-commerce site embeds a <{fencedframe}> that has a "Pay now" button. This bu
 last 4 digits of the user's credit card number as is saved with the e-commerce platform. At first,
 the {{Document}} hosted in the <{fencedframe}> has no access to the data from the e-commerce
 platform, so information can flow in and out without compromising user privacy. Because of that, the
-fenced frame is constructed directly from the web platform using the {{FencedFrameConfig}}
+fenced frame can be constructed directly from the web platform using the {{FencedFrameConfig}}
 constructor. The {{Document}} can only access that credit card data once it turns off all network
 access, preventing the data from flowing out of the fenced frame and preventing it from being joined
 with cross-site data to build a user profile.


### PR DESCRIPTION
This adds a new "use cases" subsection to the "Fenced frame configs" section. This outlines 2 use cases (ad rendering + personalized payment button) and how it relates to the different ways to build a fenced frame config. They also go into privacy stories for both use cases.

I had also considered putting this in the main "Introduction" section, but decided it was both better to keep that section brief and to put this in a place where the concept of a "fenced frame config" had already been introduced.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/WICG/fenced-frame/pull/142.html" title="Last updated on Mar 13, 2024, 11:18 PM UTC (77fcc84)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/fenced-frame/142/d6a5a54...77fcc84.html" title="Last updated on Mar 13, 2024, 11:18 PM UTC (77fcc84)">Diff</a>