### PR TITLE
Fix build failure caused by renamed WPT

### DIFF
--- a/spec.bs
+++ b/spec.bs
@@ -2947,7 +2947,8 @@ directive wouldn't give web sites enough control over their CSP rules. Introduce
   /fenced-frame/csp-fenced-frame-src-blocked.https.html
   /fenced-frame/csp-frame-src-allowed.https.html
   /fenced-frame/csp-frame-src-blocked.https.html
-  /fenced-frame/csp-transparent-url.https.html
+  /fenced-frame/csp-allowed-transparent.https.html
+  /fenced-frame/csp-blocked-transparent.https.html
   /fenced-frame/csp.https.html
   /fenced-frame/cspee.https.html
   /fenced-frame/embedder-csp-not-propagate.https.html


### PR DESCRIPTION
`csp-transparent-url` was split off into `csp-allowed-transparent` and `csp-blocked-transparent`.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/WICG/fenced-frame/pull/145.html" title="Last updated on Mar 28, 2024, 6:41 PM UTC (fed7be4)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/fenced-frame/145/fd26825...fed7be4.html" title="Last updated on Mar 28, 2024, 6:41 PM UTC (fed7be4)">Diff</a>