### PR TITLE
Spec "disable embedder-initiated nested fenced frame navigations after disabling untrusted network"

### DIFF
--- a/spec.bs
+++ b/spec.bs
@@ -516,6 +516,16 @@ The <dfn attribute for=HTMLFencedFrameElement>config</dfn> IDL attribute getter 
 
   1. If |navigation url or urn| is failure, then return.
 
+  1. Let |instance| be [=this=]'s [=relevant global object=]'s [=Window/browsing context=]'s
+     [=browsing context/fenced frame config instance=].
+
+  1. If |instance| is not null:
+     1. If |instance|'s [=fenced frame config instance/untrusted network status=] is not 
+        [=untrusted network status/enabled=], then return.
+
+     Note: Embedder-initiated navigations of fenced frame roots are not allowed after the
+     embedder's network has been disabled.
+
   1. Let |shared storage context| be the given {{FencedFrameConfig}}'s [=fencedframeconfig/
      sharedStorageContext=].
 

--- a/spec.bs
+++ b/spec.bs
@@ -2120,6 +2120,9 @@ exempt specific URLs from network revocation.
 
 Issue: This will require a RFC to add a test-only function to the WPT web driver.
 (<a href="https://github.com/WICG/fenced-frame/issues/192">WICG/fenced-frame#192</a>)
+Once that web driver changes is made, existing Chromium-internal web platform tests for
+{{Fence/disableUntrustedNetwork()}} need to be upstreamed and linked here.
+(<a href="https://github.com/WICG/fenced-frame/issues/207">WICG/fenced-frame#207</a>)
 
 <div algorithm>
   To <dfn>revoke network for a partition nonce</dfn> using a [=fenced frame config

--- a/spec.bs
+++ b/spec.bs
@@ -513,8 +513,8 @@ The <dfn attribute for=HTMLFencedFrameElement>config</dfn> IDL attribute getter 
   1. Let |instance| be [=this=]'s [=relevant global object=]'s [=Window/browsing context=]'s
      [=browsing context/fenced frame config instance=].
 
-  1. If |instance| is not null, then if |instance|'s [=fenced frame config instance/untrusted
-     network status=] is not [=untrusted network status/enabled=], then return.
+  1. If |instance| is not null, and its [=fenced frame config instance/untrusted network status=]
+     is not [=untrusted network status/enabled=], then return.
 
   1. Let |navigation url or urn| be the given {{FencedFrameConfig}}'s [=fencedframeconfig/url=] if
      the given {{FencedFrameConfig}}'s [=fencedframeconfig/url=] is not null, and the given

--- a/spec.bs
+++ b/spec.bs
@@ -510,21 +510,17 @@ The <dfn attribute for=HTMLFencedFrameElement>config</dfn> IDL attribute getter 
        Note: This holds because when the element has been removed from the DOM, its removal steps
        immediately destroy the [=fenced navigable container/fenced navigable=].
 
+  1. Let |instance| be [=this=]'s [=relevant global object=]'s [=Window/browsing context=]'s
+     [=browsing context/fenced frame config instance=].
+
+  1. If |instance| is not null, then if |instance|'s [=fenced frame config instance/untrusted
+     network status=] is not [=untrusted network status/enabled=], then return.
+
   1. Let |navigation url or urn| be the given {{FencedFrameConfig}}'s [=fencedframeconfig/url=] if
      the given {{FencedFrameConfig}}'s [=fencedframeconfig/url=] is not null, and the given
      {{FencedFrameConfig}}'s [=fencedframeconfig/urn=] otherwise.
 
   1. If |navigation url or urn| is failure, then return.
-
-  1. Let |instance| be [=this=]'s [=relevant global object=]'s [=Window/browsing context=]'s
-     [=browsing context/fenced frame config instance=].
-
-  1. If |instance| is not null:
-     1. If |instance|'s [=fenced frame config instance/untrusted network status=] is not 
-        [=untrusted network status/enabled=], then return.
-
-     1. If |instance|'s [=fenced frame config instance/has disabled untrusted network=] is true,
-        then return.
 
   1. Let |shared storage context| be the given {{FencedFrameConfig}}'s [=fencedframeconfig/
      sharedStorageContext=].

--- a/spec.bs
+++ b/spec.bs
@@ -523,8 +523,8 @@ The <dfn attribute for=HTMLFencedFrameElement>config</dfn> IDL attribute getter 
      1. If |instance|'s [=fenced frame config instance/untrusted network status=] is not 
         [=untrusted network status/enabled=], then return.
 
-     Note: Embedder-initiated navigations of fenced frame roots are not allowed after the
-     embedder's network has been disabled.
+     1. If |instance|'s [=fenced frame config instance/has disabled untrusted network=] is true,
+        then return.
 
   1. Let |shared storage context| be the given {{FencedFrameConfig}}'s [=fencedframeconfig/
      sharedStorageContext=].


### PR DESCRIPTION



<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/WICG/fenced-frame/pull/148.html" title="Last updated on Jan 21, 2025, 1:29 PM UTC (82f21b3)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/fenced-frame/148/82a9f09...82f21b3.html" title="Last updated on Jan 21, 2025, 1:29 PM UTC (82f21b3)">Diff</a>