### PR TITLE
Udpate spec for processing attribution eligible response

### DIFF
--- a/spec.bs
+++ b/spec.bs
@@ -894,9 +894,8 @@ A <dfn for=fencedframetype>destination event</dfn> is either a
 
         1. Set |processResponse| to these steps given a [=response=] |response|:
            1. Let |fenced| be true.
-           1. Let |triggerVerificationMetadata| be null.
            1. Run [=process an attribution eligible response=] with |event|'s
-              [=destination enum event/attributionReportingContextOrigin=], |attributionReportingEligibility|, |fenced|, |triggerVerificationMetadata|, and |response|.
+              [=destination enum event/attributionReportingContextOrigin=], |attributionReportingEligibility|, |fenced|, and |response|.
 
         1. Set |useParallelQueue| to true.
 

--- a/spec.bs
+++ b/spec.bs
@@ -252,6 +252,8 @@ spec: attribution-reporting; urlPrefix: https://wicg.github.io/attribution-repor
       text: event-source; url: eligibility-event-source
       text: navigation-source; url: eligibility-navigation-source
       text: unset; url: eligibility-unset
+    for: request
+      text: trigger verification metadata; url: request-trigger-verification-metadata
 spec: turtledove; urlPrefix: https://wicg.github.io/turtledove/
   type: dfn
     text: construct a pending fenced frame config; url: construct-a-pending-fenced-frame-config
@@ -893,9 +895,9 @@ A <dfn for=fencedframetype>destination event</dfn> is either a
         1. Otherwise, set |attributionReportingEligibility| to "<code>[=eligibility/event-source=]</code>".
 
         1. Set |processResponse| to these steps given a [=response=] |response|:
-
+           1. Let |fenced| be true.
            1. Run [=process an attribution eligible response=] with |event|'s
-              [=destination enum event/attributionReportingContextOrigin=], |attributionReportingEligibility|, and |response|.
+              [=destination enum event/attributionReportingContextOrigin=], |attributionReportingEligibility|, |fenced|, |request|'s [=request/trigger verification metadata=], and |response|.
 
         1. Set |useParallelQueue| to true.
 

--- a/spec.bs
+++ b/spec.bs
@@ -252,8 +252,6 @@ spec: attribution-reporting; urlPrefix: https://wicg.github.io/attribution-repor
       text: event-source; url: eligibility-event-source
       text: navigation-source; url: eligibility-navigation-source
       text: unset; url: eligibility-unset
-    for: request
-      text: trigger verification metadata; url: request-trigger-verification-metadata
 spec: turtledove; urlPrefix: https://wicg.github.io/turtledove/
   type: dfn
     text: construct a pending fenced frame config; url: construct-a-pending-fenced-frame-config
@@ -896,8 +894,9 @@ A <dfn for=fencedframetype>destination event</dfn> is either a
 
         1. Set |processResponse| to these steps given a [=response=] |response|:
            1. Let |fenced| be true.
+           1. Let |triggerVerificationMetadata| be null.
            1. Run [=process an attribution eligible response=] with |event|'s
-              [=destination enum event/attributionReportingContextOrigin=], |attributionReportingEligibility|, |fenced|, |request|'s [=request/trigger verification metadata=], and |response|.
+              [=destination enum event/attributionReportingContextOrigin=], |attributionReportingEligibility|, |fenced|, |triggerVerificationMetadata|, and |response|.
 
         1. Set |useParallelQueue| to true.
 


### PR DESCRIPTION
`Process an attribution eligible response` interface was changed in  https://github.com/WICG/attribution-reporting-api/pull/1238.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/linnan-github/fenced-frame/pull/150.html" title="Last updated on Aug 14, 2024, 2:52 PM UTC (bef63a5)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/fenced-frame/150/c799ffe...linnan-github:bef63a5.html" title="Last updated on Aug 14, 2024, 2:52 PM UTC (bef63a5)">Diff</a>