### PR TITLE
Spec cross-origin reportEvent() support

### DIFF
--- a/spec.bs
+++ b/spec.bs
@@ -1145,10 +1145,10 @@ A <dfn export>fenced frame config</dfn> is a [=struct=] with the following [=str
   :: null, or a [=string=]
   
   : <dfn>is ad component</dfn>
-  :: A [=boolean=]. Defaulting to false.
+  :: A [=boolean=], initially false.
 
   : <dfn>cross-origin reporting allowed</dfn>
-  :: A [=boolean=]. Defaulting to false.
+  :: A [=boolean=], initially false.
 </dl>
   
   Note: When true, this [=fenced frame config=] reprsents an ad component. An ad component can be
@@ -1204,7 +1204,7 @@ A <dfn export>fenced frame config instance</dfn> is a [=struct=] with the follow
   :: A [=boolean=], initially false.
 
   : <dfn>cross-origin reporting allowed</dfn>
-  :: A [=boolean=]. Defaulting to false.
+  :: A [=boolean=], initially false.
 </dl>
 
 <div algorithm>
@@ -1499,10 +1499,11 @@ Several APIs specific to fenced frames are defined on the {{Fence}} interface.
   };
 
   dictionary FenceEvent {
-    // This dictionary has two mutually exclusive modes:
-
-    // When reporting to a preregistered destination (specified by enum), the
-    // following properties are used:
+    // This dictionary has two mutually exclusive modes that aren't represented as
+    // distinct IDL types due to distinguishability issues:
+    //
+    // When reporting to a preregistered destination (specified by enum), the following
+    // properties are used:
     DOMString eventType;
     DOMString eventData;
     sequence&lt;FenceReportingDestination&gt; destination;
@@ -1517,12 +1518,10 @@ Several APIs specific to fenced frames are defined on the {{Fence}} interface.
 
     // When setting event data to be used later in an automatic beacon, the
     // following properties are used:
-    // Determines if the beacon data will be used for only the next automatic
-    // beacon event, or if it will be reused for all subsequent automatic beacons.
     boolean once = false;
 
-    // When reporting to a custom destination URL (with substitution of macros
-    // defined by the buyer), the following property is used:
+    // When reporting to a custom destination URL (with substitution of macros defined by
+    // the Protected Audience buyer), the following property is used:
     USVString destinationURL;
   };
 
@@ -2693,11 +2692,6 @@ CORP violation report=] algorithm, as leaving it unfenced may cause a privacy le
       1. Set |config|'s [=fenced frame config/embedder shared storage context=] to
          |sharedStorageContext|.
 
-      1. If |response| is non-null, set |config|'s [=fenced frame config/cross-origin reporting
-         allowed=] to the result of running [=header list/get a structured field value=] on
-         |response|'s [=response/header list=] given
-         "<code>Allow-Cross-Origin-Event-Reporting</code>" and "`item`".
-
       1. Set <var ignore>sourceSnapshotParams</var>'s [=source snapshot params/target fenced frame
          config=] to |config|.
 
@@ -2784,6 +2778,12 @@ content in the <{fencedframe}> or its embedder, exactly one of two things will h
        Note: This is because embedder-initiated navigations (indicated by |navigationParams|'s
        [=navigation params/fenced frame config instance=] being non-null) always cause a
        [[#bcg-swap]].
+
+    1. Set |navigationParams|'s [=navigation params/fenced frame config instance=]'s [=fenced frame
+       config/cross-origin reporting allowed=] to the result of running [=header list/get a
+       structured field value=] on |navigationParams|'s [=navigation params/response=]'s
+       [=response/header list=] given "<code>Allow-Cross-Origin-Event-Reporting</code>" and
+       "`item`".
 
     1. Set |browsingContext|'s [=browsing context/fenced frame config instance=] to
        |navigationParams|'s [=navigation params/fenced frame config instance=].

--- a/spec.bs
+++ b/spec.bs
@@ -1146,6 +1146,9 @@ A <dfn export>fenced frame config</dfn> is a [=struct=] with the following [=str
   
   : <dfn>is ad component</dfn>
   :: A [=boolean=]. Defaulting to false.
+
+  : <dfn>cross-origin reporting allowed</dfn>
+  :: A [=boolean=]. Defaulting to false.
 </dl>
   
   Note: When true, this [=fenced frame config=] reprsents an ad component. An ad component can be
@@ -1199,6 +1202,9 @@ A <dfn export>fenced frame config instance</dfn> is a [=struct=] with the follow
   
   : <dfn>is ad component</dfn>
   :: A [=boolean=], initially false.
+
+  : <dfn>cross-origin reporting allowed</dfn>
+  :: A [=boolean=]. Defaulting to false.
 </dl>
 
 <div algorithm>
@@ -1283,6 +1289,9 @@ A <dfn export>fenced frame config instance</dfn> is a [=struct=] with the follow
     
     : [=fenced frame config instance/is ad component=]
     :: |config|'s [=fenced frame config/is ad component=]
+
+    : [=fenced frame config instance/cross-origin reporting allowed=]
+    :: |config|'s [=fenced frame config/cross-origin reporting allowed=]
 </div>
 
 Each [=browsing context=] has a <dfn for="browsing context">fenced frame config instance</dfn>,
@@ -1490,22 +1499,30 @@ Several APIs specific to fenced frames are defined on the {{Fence}} interface.
   };
 
   dictionary FenceEvent {
-    // This dictionary has two mutually exclusive modes that aren't represented as
-    // distinct IDL types due to distinguishability issues:
-    //
-    // When reporting to a preregistered destination (specified by enum), the following
-    // properties are used:
+    // This dictionary has two mutually exclusive modes:
+
+    // When reporting to a preregistered destination (specified by enum), the
+    // following properties are used:
     DOMString eventType;
     DOMString eventData;
     sequence&lt;FenceReportingDestination&gt; destination;
-    
-    // When setting event data to be used later in an automatic beacon, the
-    // following properties are used:
-    boolean once = false;
+
+    // Determines if this data can be sent in a reportEvent() beacon or automatic
+    // beacon that originates from a document that is cross-origin to the mapped
+    // URL of the fenced frame config that loaded this frame tree.
+    // Note that automatic beacon data can only be set from documents that are
+    // same-origin to the fenced frame config's mapped URL, so this effectively
+    // opts in the data to being used in a cross-origin subframe.
     boolean crossOriginExposed = false;
 
-    // When reporting to a custom destination URL (with substitution of macros defined by
-    // the Protected Audience buyer), the following property is used:
+    // When setting event data to be used later in an automatic beacon, the
+    // following properties are used:
+    // Determines if the beacon data will be used for only the next automatic
+    // beacon event, or if it will be reused for all subsequent automatic beacons.
+    boolean once = false;
+
+    // When reporting to a custom destination URL (with substitution of macros
+    // defined by the buyer), the following property is used:
     USVString destinationURL;
   };
 
@@ -1529,18 +1546,30 @@ Several APIs specific to fenced frames are defined on the {{Fence}} interface.
   
   1. If |instance|'s [=fenced frame config instance/is ad component=] is true, then return.
 
-  1. If the [=relevant settings object=]'s [=environment settings object/origin=] and |instance|'s
-     [=fenced frame config instance/mapped url=]'s [=url/origin=] are not [=same origin=], then
-     return.
-
   1. If |instance|'s [=fenced frame config instance/fenced frame reporter=] is null, then return.
 
-  1. If |event| is a {{DOMString}}, run [=report a private aggregation event=] using |instance|'s
-     [=fenced frame config instance/fenced frame reporter=] with |event|.
+  1. If |event| is a {{DOMString}}:
+
+     1. If the [=relevant settings object=]'s [=environment settings object/origin=] and
+        |instance|'s [=fenced frame config instance/mapped url=]'s [=url/origin=] are not [=same
+        origin=], then return.
+  
+     1. Run [=report a private aggregation event=] using |instance|'s [=fenced frame config
+        instance/fenced frame reporter=] with |event|.
 
   1. If |event| is a {{FenceEvent}}:
 
      1. If |event|'s {{FenceEvent/eventType}} [=string/starts with=] "`reserved.`", then return.
+
+     1. If all of the following conditions are true:
+
+        * the [=relevant settings object=]'s [=environment settings object/origin=] and
+          |instance|'s [=fenced frame config instance/mapped url=]'s [=url/origin=] are not [=same
+          origin=];
+        * either |event|'s {{FenceEvent/crossOriginExposed}} is false or |instance|'s
+          [=fenced frame config instance/cross-origin reporting allowed=] is false;   
+
+        then return.
 
      1. If |event| has a {{FenceEvent/destinationURL}}:
         1. If |event| has a {{FenceEvent/destination}} or a {{FenceEvent/eventType}} or a
@@ -1595,6 +1624,17 @@ Several APIs specific to fenced frames are defined on the {{Fence}} interface.
   <wpt>
     /fenced-frame/fence-report-event.https.html
     /fenced-frame/fence-report-event-destination-url.https.html
+    /fenced-frame/fence-report-event-cross-origin-content-initiated.https.html 
+    /fenced-frame/fence-report-event-cross-origin-nested-urn-iframe.https.html 
+    /fenced-frame/fence-report-event-cross-origin-nested.https.html 
+    /fenced-frame/fence-report-event-cross-origin-no-embedder-opt-in.https.html 
+    /fenced-frame/fence-report-event-cross-origin-no-subframe-opt-in.https.html 
+    /fenced-frame/fence-report-event-cross-origin-urn-iframe-content-initiated.https.html 
+    /fenced-frame/fence-report-event-cross-origin-urn-iframe-no-embedder-opt-in.https.html 
+    /fenced-frame/fence-report-event-cross-origin-urn-iframe-no-subframe-opt-in.https.html 
+    /fenced-frame/fence-report-event-cross-origin-urn-iframe.https.html 
+    /fenced-frame/fence-report-event-cross-origin.https.html 
+    /fenced-frame/fence-report-event-sub-fencedframe.https.html 
   </wpt>
 </div>
 
@@ -2652,6 +2692,11 @@ CORP violation report=] algorithm, as leaving it unfenced may cause a privacy le
 
       1. Set |config|'s [=fenced frame config/embedder shared storage context=] to
          |sharedStorageContext|.
+
+      1. If |response| is non-null, set |config|'s [=fenced frame config/cross-origin reporting
+         allowed=] to the result of running [=header list/get a structured field value=] on
+         |response|'s [=response/header list=] given
+         "<code>Allow-Cross-Origin-Event-Reporting</code>" and "`item`".
 
       1. Set <var ignore>sourceSnapshotParams</var>'s [=source snapshot params/target fenced frame
          config=] to |config|.

--- a/spec.bs
+++ b/spec.bs
@@ -1549,7 +1549,7 @@ Several APIs specific to fenced frames are defined on the {{Fence}} interface.
 
   1. If |event| is a {{DOMString}}:
 
-     1. If the [=relevant settings object=]'s [=environment settings object/origin=] and
+     1. If [=this=]'s [=relevant settings object=]'s [=environment settings object/origin=] and
         |instance|'s [=fenced frame config instance/mapped url=]'s [=url/origin=] are not [=same
         origin=], then return.
   
@@ -1562,7 +1562,7 @@ Several APIs specific to fenced frames are defined on the {{Fence}} interface.
 
      1. If all of the following conditions are true:
 
-        * the [=relevant settings object=]'s [=environment settings object/origin=] and
+        * [=this=]'s [=relevant settings object=]'s [=environment settings object/origin=] and
           |instance|'s [=fenced frame config instance/mapped url=]'s [=url/origin=] are not [=same
           origin=];
         * either |event|'s {{FenceEvent/crossOriginExposed}} is false or |instance|'s
@@ -1652,9 +1652,9 @@ Several APIs specific to fenced frames are defined on the {{Fence}} interface.
 
   1. If |instance| is null, then return.
 
-  1. If the [=relevant settings object=]'s [=environment settings object/origin=] and |instance|'s
-     [=fenced frame config instance/mapped url=]'s [=url/origin=] are not [=same origin=], then
-     return.
+  1. If [=this=]'s [=relevant settings object=]'s [=environment settings object/origin=] and
+     |instance|'s [=fenced frame config instance/mapped url=]'s [=url/origin=] are not [=same
+     origin=], then return.
 
   1. If |instance|'s [=fenced frame config instance/fenced frame reporter=] is null, then return.
 
@@ -1688,9 +1688,9 @@ Several APIs specific to fenced frames are defined on the {{Fence}} interface.
 
   1. If |instance| is null, then return.
 
-  1. If the [=relevant settings object=]'s [=environment settings object/origin=] and |instance|'s
-     [=fenced frame config instance/mapped url=]'s [=url/origin=] are not [=same origin=], then
-     return.
+  1. If [=this=]'s [=relevant settings object=]'s [=environment settings object/origin=] and
+     |instance|'s [=fenced frame config instance/mapped url=]'s [=url/origin=] are not [=same
+     origin=], then return.
 
   1. If |instance|'s [=fenced frame config instance/nested configs=] is null, then return.
 


### PR DESCRIPTION
Reporting beacons can now be sent with `window.fence.reportEvent()` from documents that are cross origin to a fenced frame config's mapped URL. To do this, there must be opt-in from both the document created with the FencedFrameConfig as well as the cross-origin document that wants to send the beacon. The document created with the FencedFrameConfig opts in with a new "Allow-Cross-Origin-Event-Reporting=true" response header. The cross-origin document opts in by calling `reportEvent()` with the `crossOriginExposed=true` parameter.

This PR updates the spec to match that behavior. More specifically:
- Updates the FenceEvent IDL to match the [current .idl file](https://source.chromium.org/chromium/chromium/src/+/main:third_party/blink/renderer/core/html/fenced_frame/fence_event.idl) on the codebase.
- Adds a way to store a new "Allow-Cross-Origin-Event-Reporting" opt-in header in the fenced frame config. This header is set in the document whose browsing context houses the fenced frame config. It makes most sense to store this in the fenced frame config directly, since it will be consulting that when calling reportEvent() anyway, and cross-origin iframes still have access to the fenced frame config instance object.
- Modifies `reportEvent()` to support being called from a document that is cross-origin to the fenced frame config's mapped URL.
  - The private aggregation path has no changes, as it still doesn't have cross-origin support.
  - The destination enum/URL path adds a carve-out that allows it to continue if it's cross-origin but also has both header opt-in for the document that owns the fenced frame config + `crossOriginExposed=true` opt-in from the document that's sending the beacon.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/WICG/fenced-frame/pull/152.html" title="Last updated on Apr 30, 2024, 3:34 PM UTC (c899272)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/fenced-frame/152/b1c7abe...c899272.html" title="Last updated on Apr 30, 2024, 3:34 PM UTC (c899272)">Diff</a>