### PR TITLE
Spec for window.fence.notifyEvent and onfencedtreeclick

### DIFF
--- a/spec.bs
+++ b/spec.bs
@@ -1644,7 +1644,7 @@ Several APIs specific to fenced frames are defined on the {{Fence}} interface.
       undefined reportEvent(optional ReportEventType event = {});
       undefined setReportEventDataForAutomaticBeacons(optional FenceEvent event = {});
       sequence&lt;FencedFrameConfig&gt; getNestedConfigs();
-      undefined notifyEvent(optional Event event = {});
+      undefined notifyEvent(Event event);
   };
 </pre>
 
@@ -1841,8 +1841,6 @@ Several APIs specific to fenced frames are defined on the {{Fence}} interface.
   1. If any of the following conditions are met, throw a {{SecurityError}} {{DOMException}}:
 
       * |navigable| is not a [=fenced navigable container/fenced navigable=];
-
-      * |event| is null;
   
       * |event|'s {{Event/isTrusted}} is false;
   
@@ -1857,13 +1855,13 @@ Several APIs specific to fenced frames are defined on the {{Fence}} interface.
   1. Let |parentNavigable| be |navigable|'s [=navigable/unfenced parent=].
 
   1. [=Queue a global task=] on the [=DOM manipulation task source=] given |parentNavigable|'s     
-     [=navigable/active window=] to fire a "<code>[=fencedtreeclick=]</code>" event:
+     [=navigable/active window=] to run these steps:
   
      1. Perform the [=activation notification=] steps.
 
      1. [=Fire an event=] named "<code>[=fencedtreeclick=]</code>" at |navigable|'s 
         [=fenced navigable container=]. Initialize the event's {{Event/bubbles}} and {{Event/cancelable}} attributes to `true`. When running the 
-        <a href="https://dom.spec.whatwg.org/#inner-event-creation-steps">inner event creation steps</a>, set the <var ignore=''>time</var> to a user-agent-defined value that is consistent across all invocations of this method.
+        <a href="https://dom.spec.whatwg.org/#inner-event-creation-steps">inner event creation steps</a>, set the <var ignore=''>time</var> to an [=implementation-defined=] value that is consistent across all invocations of this method.
 
   <wpt>
     /fenced-frame/notify-event-iframe.https.html

--- a/spec.bs
+++ b/spec.bs
@@ -117,6 +117,7 @@ spec: html; urlPrefix: https://html.spec.whatwg.org/multipage/
       text: create a new browsing context and document; url: creating-a-new-browsing-context
       text: create a new browsing context group and document; url: creating-a-new-browsing-context-group
       text: document base url; url: document-base-url
+      text: fully active; url: fully-active
       text: initialize the navigable; url: initialize-the-navigable
       text: node navigable; url: node-navigable
       text: system visibility state; url: system-visibility-state
@@ -164,6 +165,7 @@ spec: html; urlPrefix: https://html.spec.whatwg.org/multipage/
     urlPrefix: interaction.html
       text: activation notification; url: activation-notification
       text: consume user activation; url: consume-user-activation
+      text: transient activation; url: transient-activation 
       text: activation; url: activation
       text: click focusable; url: click-focusable
       text: focusable area; url: focusable-area
@@ -188,6 +190,8 @@ spec: html; urlPrefix: https://html.spec.whatwg.org/multipage/
       for: environment
         text: target browsing context; url: concept-environment-target-browsing-context
       text: navigation and traversal task source
+      text: event handlers on elements, document objects, and window objects; url: event-handlers-on-elements,-document-objects,-and-window-objects
+      text: idl definitions; url: idl-definitions
     urlPrefix: document-sequences.html
       for: browsing context
         text: active document; url: active-document
@@ -1633,6 +1637,7 @@ Several APIs specific to fenced frames are defined on the {{Fence}} interface.
       undefined reportEvent(optional ReportEventType event = {});
       undefined setReportEventDataForAutomaticBeacons(optional FenceEvent event = {});
       sequence&lt;FencedFrameConfig&gt; getNestedConfigs();
+      undefined notifyEvent(optional Event event = {});
   };
 </pre>
 
@@ -1836,6 +1841,45 @@ Several APIs specific to fenced frames are defined on the {{Fence}} interface.
   <wpt>
     /fenced-frame/get-nested-configs.https.html
     /fenced-frame/config-cross-origin-apis.https.html
+  </wpt>
+</div>
+
+<div algorithm>
+  The <dfn method for=Fence>notifyEvent(|event|)</dfn> method steps are:
+
+  1. [=Assert=]: [=this=]'s {{Document}} is [=fully active=].
+
+  1. Let |navigable| be [=this=]'s [=relevant global object=]'s [=navigable=].
+  
+  1. If |navigable| is not a [=fenced navigable container/fenced navigable=], then
+     throw a {{SecurityError}} {{DOMException}}.
+
+  1. If |event| is null, then throw a {{SecurityError}} {{DOMException}}.
+  
+  1. If |event|'s {{Event/isTrusted}} is false, then throw a {{SecurityError}} {{DOMException}}.
+  
+  1. If |event|'s [=Event/dispatch flag=] is unset, then throw a {{SecurityError}} {{DOMException}}.
+
+  1. If |event|'s  {{Event/type}} is not "fencedtreeclick", throw a {{SecurityError}} 
+     {{DOMException}}.
+  
+  1. If [=this=]'s [=relevant global object=] does not have [=transient activation=], then return.
+
+  1. [=Consume user activation=] for [=this=]'s [=relevant global object=].
+
+  1. [=Fire an event=] named "fencedtreeclick" at |navigable|'s 
+     [=fenced navigable container=]. Initialize the event's {{Event/bubbles}} and {{Event/cancelable}}
+     attributes to `true`. When running the 
+     <a href="https://dom.spec.whatwg.org/#inner-event-creation-steps">inner event creation steps</a>, 
+     set the <var ignore=''>time</var> to a user-agent-defined value that is consistent across all 
+     invocations of this method.
+
+  <wpt>
+    /fenced-frame/notify-event-iframe.https.html
+    /fenced-frame/notify-event-invalid.https.html
+    /fenced-frame/notify-event-nested-fenced-frames.https.html
+    /fenced-frame/notify-event-success.https.html
+    /fenced-frame/notify-event-transient-user-activation.https.html
   </wpt>
 </div>
 
@@ -2954,6 +2998,22 @@ The <a href=https://html.spec.whatwg.org/#page-visibility>Page visibility</a> se
 modified such that the first step of the algorithm that runs when a user-agent changes a
 [=traversable navigable=]'s [=system visibility state=] calls the [=Document/inclusive descendant
 navigables=] algorithm with [=inclusive-dn-unfenced|unfenced=] set to true.
+
+<h3 id=events>Events</h3>
+
+The {{Fence/notifyEvent}} method of the {{Fence}} interface introduces a new event type, `fencedtreeclick`.
+
+The [=event handlers on elements, Document objects, and Window objects=] section of [[HTML]] is modified to 
+include a new row. The [=event handler=] name is `onfencedtreeclick`, and the [=event handler event type=] is
+`fencedtreeclick`.
+
+The {{GlobalEventHandlers}} interface is modified as follows:
+
+<pre class=idl>
+  partial interface mixin GlobalEventHandlers {
+    attribute EventHandler onfencedtreeclick;
+  };
+</pre>
 
 <h2 id="interaction-with-other-specs">Interactions with other specifications</h2>
 

--- a/spec.bs
+++ b/spec.bs
@@ -1851,17 +1851,17 @@ Several APIs specific to fenced frames are defined on the {{Fence}} interface.
 
   1. Let |navigable| be [=this=]'s [=relevant global object=]'s [=navigable=].
   
-  1. If |navigable| is not a [=fenced navigable container/fenced navigable=], then
-     throw a {{SecurityError}} {{DOMException}}.
+  1. If any of the following conditions are met, throw a {{SecurityError}} {{DOMException}}:
 
-  1. If |event| is null, then throw a {{SecurityError}} {{DOMException}}.
-  
-  1. If |event|'s {{Event/isTrusted}} is false, then throw a {{SecurityError}} {{DOMException}}.
-  
-  1. If |event|'s [=Event/dispatch flag=] is unset, then throw a {{SecurityError}} {{DOMException}}.
+      1. |navigable| is not a [=fenced navigable container/fenced navigable=].
 
-  1. If |event|'s  {{Event/type}} is not "fencedtreeclick", throw a {{SecurityError}} 
-     {{DOMException}}.
+      1. |event| is null.
+  
+      1. |event|'s {{Event/isTrusted}} is false.
+  
+      1. |event|'s [=Event/dispatch flag=] is unset.
+
+      1. |event|'s  {{Event/type}} is not "fencedtreeclick".
   
   1. If [=this=]'s [=relevant global object=] does not have [=transient activation=], then return.
 

--- a/spec.bs
+++ b/spec.bs
@@ -1848,18 +1848,20 @@ Several APIs specific to fenced frames are defined on the {{Fence}} interface.
   
       * |event|'s [=Event/dispatch flag=] is unset;
 
-      * |event|'s {{Event/type}} is not <code>click</code>
+      * |event|'s {{Event/type}} is not "<code>click</code>"
   
   1. If [=this=]'s [=relevant global object=] does not have [=transient activation=], then return.
 
   1. [=Consume user activation=] for [=this=]'s [=relevant global object=].
 
-  1. [=Fire an event=] named <code>[=fencedtreeclick=]</code> at |navigable|'s 
-     [=fenced navigable container=]. Initialize the event's {{Event/bubbles}} and {{Event/cancelable}}
-     attributes to `true`. When running the 
-     <a href="https://dom.spec.whatwg.org/#inner-event-creation-steps">inner event creation steps</a>, 
-     set the <var ignore=''>time</var> to a user-agent-defined value that is consistent across all 
-     invocations of this method.
+  1. Let |parentNavigable| be |navigable|'s [=navigable/unfenced parent=].
+
+  1. [=Queue a global task=] on the [=DOM manipulation task source=] given |parentNavigable|'s     
+     [=navigable/active window=] to fire a "<code>[=fencedtreeclick=]</code>" event:
+  
+     1. [=Fire an event=] named "<code>[=fencedtreeclick=]</code>" at |navigable|'s 
+        [=fenced navigable container=]. Initialize the event's {{Event/bubbles}} and {{Event/cancelable}} attributes to `true`. When running the 
+        <a href="https://dom.spec.whatwg.org/#inner-event-creation-steps">inner event creation steps</a>, set the <var ignore=''>time</var> to a user-agent-defined value that is consistent across all invocations of this method.
 
   <wpt>
     /fenced-frame/notify-event-iframe.https.html
@@ -3004,38 +3006,9 @@ navigables=] algorithm with [=inclusive-dn-unfenced|unfenced=] set to true.
 
 <h3 id=events>Events</h3>
 
-<h4 id=fencedtreeclick-header><code>fencedtreeclick</code> event type</h4>
-The <a href="https://html.spec.whatwg.org/C#events-2">Events</a> table in the
-<a href="https://html.spec.whatwg.org/multipage/indices.html">Index</a> section of [[HTML]] is
-modified to include a new row.
-
-<table>
-  <thead>
-    <tr>
-      <th>Event</th> 
-      <th>Interface</th> 
-      <th>Interesting targets</th> 
-      <th>Description</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td><dfn><code>fencedtreeclick</code></dfn></td> 
-      <td>{{Event}}</td> 
-      <td>Elements</td>
-      <td>
-        Fired at a <{fencedframe}> element asynchronously after its
-        [=fenced navigable container/fenced navigable=]'s {{Document}} calls {{Fence/notifyEvent()}}
-      </td>
-    </tr>
-  </tbody>
-</table>
-
-<h4 id=onfencedtreeclick-header><code>onfencedtreeclick</code> event handler</h4>
+<h4 id=onfencedtreeclick-header><code>[=onfencedtreeclick=]</code> event handler</h4>
 The table in the <a href="https://html.spec.whatwg.org/multipage/webappapis.html#event-handlers-on-elements,-document-objects,-and-window-objects">
-event handlers on elements, Document objects, and Window objects</a> section of [[HTML]] is modified 
-to include a new row. The [=event handler=] name is <code>onfencedtreeclick</code>, and the 
-[=event handler event type=] is <code>fencedtreeclick</code>.
+event handlers on elements, Document objects, and Window objects</a> section of [[HTML]] is modified to include a new row.
 
 <table>
   <thead>
@@ -3064,6 +3037,33 @@ Additionally, the list of [=event handler content attributes which may be specif
 in [[HTML]] is modified to include a new row:
 
 * [=onfencedtreeclick=]
+
+<h4 id=fencedtreeclick-header><code>[=fencedtreeclick=]</code> event type</h4>
+The <a href="https://html.spec.whatwg.org/C#events-2">Events</a> table in the
+<a href="https://html.spec.whatwg.org/multipage/indices.html">Index</a> section of [[HTML]] is
+modified to include a new row.
+
+<table>
+  <thead>
+    <tr>
+      <th>Event</th> 
+      <th>Interface</th> 
+      <th>Interesting targets</th> 
+      <th>Description</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td><dfn><code>fencedtreeclick</code></dfn></td> 
+      <td>{{Event}}</td> 
+      <td>Elements</td>
+      <td>
+        Fired at a <{fencedframe}> element asynchronously after its
+        [=fenced navigable container/fenced navigable=]'s {{Document}} calls {{Fence/notifyEvent()}}
+      </td>
+    </tr>
+  </tbody>
+</table>
 
 <h2 id="interaction-with-other-specs">Interactions with other specifications</h2>
 

--- a/spec.bs
+++ b/spec.bs
@@ -192,8 +192,6 @@ spec: html; urlPrefix: https://html.spec.whatwg.org/multipage/
       for: environment
         text: target browsing context; url: concept-environment-target-browsing-context
       text: navigation and traversal task source
-      text: event handlers on elements, document objects, and window objects; url: event-handlers-on-elements,-document-objects,-and-window-objects
-      text: idl definitions; url: idl-definitions
     urlPrefix: document-sequences.html
       for: browsing context
         text: active document; url: active-document
@@ -1838,7 +1836,7 @@ Several APIs specific to fenced frames are defined on the {{Fence}} interface.
 
   1. Let |navigable| be [=this=]'s [=relevant global object=]'s [=Window/navigable=].
   
-  1. If any of the following conditions are met, throw a {{SecurityError}} {{DOMException}}:
+  1. If any of the following conditions are met, then throw a {{SecurityError}} {{DOMException}}:
 
       * |navigable| is not a [=fenced navigable container/fenced navigable=];
   

--- a/spec.bs
+++ b/spec.bs
@@ -106,6 +106,7 @@ spec: html; urlPrefix: https://html.spec.whatwg.org/multipage/
       text: dom interface; url: concept-element-dom
       text: accessibility considerations; url: concept-element-accessibility-considerations
       text: represents; url: represents
+      text: event handler content attributes which may be specified on any HTML element; url: global-attributes:event-handler-content-attributes
     urlPrefix: common-dom-interfaces.html
       text: reflect; url: reflect
     urlPrefix: embedder-content-other.html
@@ -355,6 +356,14 @@ dl, dd {
   background: white;
   border: solid #D50606;
 }
+
+/* Table styling definitions from https://resources.whatwg.org/standard.css */
+table { border-collapse: collapse; border-style: hidden hidden none hidden; margin: 1.25em 0; }
+table thead, table tbody { border-bottom: solid; }
+table tbody th { text-align: left; }
+table tbody th:first-child { border-left: solid; }
+table td, table th { border-left: solid; border-right: solid; border-bottom: solid thin; vertical-align: top; padding: 0.2em; }
+
 </style>
 
 <script src="https://resources.whatwg.org/file-issue.js" async></script>
@@ -1845,7 +1854,7 @@ Several APIs specific to fenced frames are defined on the {{Fence}} interface.
 <div algorithm>
   The <dfn method for=Fence>notifyEvent(|event|)</dfn> method steps are:
 
-  1. [=Assert=]: [=this=]'s {{Document}} is [=Document/fully active=].
+  1. If [=this=]'s {{Document}} is not [=Document/fully active=], then return.
 
   1. Let |navigable| be [=this=]'s [=relevant global object=]'s [=navigable=].
   
@@ -1859,7 +1868,7 @@ Several APIs specific to fenced frames are defined on the {{Fence}} interface.
   
       * |event|'s [=Event/dispatch flag=] is unset;
 
-      * |event|'s {{Event/type}} is not <code>[=fencedtreeclick=]</code>
+      * |event|'s {{Event/type}} is not <code>click</code>
   
   1. If [=this=]'s [=relevant global object=] does not have [=transient activation=], then return.
 
@@ -2999,12 +3008,52 @@ navigables=] algorithm with [=inclusive-dn-unfenced|unfenced=] set to true.
 
 <h3 id=events>Events</h3>
 
-The {{Fence/notifyEvent}} method of the {{Fence}} interface introduces a new event type, <code><dfn>fencedtreeclick</dfn></code>.
+<h4 id=fencedtreeclick-header><code>fencedtreeclick</code> event type</h4>
+The <a href="https://html.spec.whatwg.org/C#events-2">Events</a> table in the
+<a href="https://html.spec.whatwg.org/multipage/indices.html">Index</a> section of [[HTML]] is
+modified to include a new row.
 
-The <a href="https://html.spec.whatwg.org/multipage/webappapis.html#event-handlers-on-elements,-document-objects,-and-window-objects">
-event handlers on elements, Document objects, and Window objects</a> section of [[HTML]] is modified to 
-include a new row. The [=event handler=] name is <code>onfencedtreeclick</code>, and the [=event handler event type=] is
-<code>[=fencedtreeclick=]</code>.
+<table>
+  <thead>
+    <tr>
+      <th>Event</th> 
+      <th>Interface</th> 
+      <th>Interesting targets</th> 
+      <th>Description</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td><dfn export><code>fencedtreeclick</code></dfn></td> 
+      <td>{{Event}}</td> 
+      <td>Elements</td>
+      <td>
+        Fired at a <{fencedframe}> element when its contained content calls {{Fence/notifyEvent}}
+      </td>
+    </tr>
+  </tbody>
+</table>
+
+<h4 id=onfencedtreeclick-header><code>onfencedtreeclick</code> event handler</h4>
+The table in the <a href="https://html.spec.whatwg.org/multipage/webappapis.html#event-handlers-on-elements,-document-objects,-and-window-objects">
+event handlers on elements, Document objects, and Window objects</a> section of [[HTML]] is modified 
+to include a new row. The [=event handler=] name is <code>onfencedtreeclick</code>, and the 
+[=event handler event type=] is <code>fencedtreeclick</code>.
+
+<table>
+  <thead>
+    <tr>
+      <th>[=Event handler=]</th> 
+      <th>[=Event handler event type=]</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td><dfn export><code>onfencedtreeclick</code></dfn></td>
+      <td><code>[=fencedtreeclick=]</code></td>
+    </tr>
+  </tbody>
+</table>
 
 The {{GlobalEventHandlers}} interface is modified as follows:
 
@@ -3013,6 +3062,11 @@ The {{GlobalEventHandlers}} interface is modified as follows:
     attribute EventHandler onfencedtreeclick;
   };
 </pre>
+
+Additionally, the list of [=event handler content attributes which may be specified on any HTML element=] 
+in [[HTML]] is modified to include a new row:
+
+* [=onfencedtreeclick=]
 
 <h2 id="interaction-with-other-specs">Interactions with other specifications</h2>
 

--- a/spec.bs
+++ b/spec.bs
@@ -117,7 +117,6 @@ spec: html; urlPrefix: https://html.spec.whatwg.org/multipage/
       text: create a new browsing context and document; url: creating-a-new-browsing-context
       text: create a new browsing context group and document; url: creating-a-new-browsing-context-group
       text: document base url; url: document-base-url
-      text: fully active; url: fully-active
       text: initialize the navigable; url: initialize-the-navigable
       text: node navigable; url: node-navigable
       text: system visibility state; url: system-visibility-state
@@ -165,7 +164,6 @@ spec: html; urlPrefix: https://html.spec.whatwg.org/multipage/
     urlPrefix: interaction.html
       text: activation notification; url: activation-notification
       text: consume user activation; url: consume-user-activation
-      text: transient activation; url: transient-activation 
       text: activation; url: activation
       text: click focusable; url: click-focusable
       text: focusable area; url: focusable-area
@@ -1847,27 +1845,27 @@ Several APIs specific to fenced frames are defined on the {{Fence}} interface.
 <div algorithm>
   The <dfn method for=Fence>notifyEvent(|event|)</dfn> method steps are:
 
-  1. [=Assert=]: [=this=]'s {{Document}} is [=fully active=].
+  1. [=Assert=]: [=this=]'s {{Document}} is [=Document/fully active=].
 
   1. Let |navigable| be [=this=]'s [=relevant global object=]'s [=navigable=].
   
   1. If any of the following conditions are met, throw a {{SecurityError}} {{DOMException}}:
 
-      1. |navigable| is not a [=fenced navigable container/fenced navigable=].
+      * |navigable| is not a [=fenced navigable container/fenced navigable=];
 
-      1. |event| is null.
+      * |event| is null;
   
-      1. |event|'s {{Event/isTrusted}} is false.
+      * |event|'s {{Event/isTrusted}} is false;
   
-      1. |event|'s [=Event/dispatch flag=] is unset.
+      * |event|'s [=Event/dispatch flag=] is unset;
 
-      1. |event|'s  {{Event/type}} is not "fencedtreeclick".
+      * |event|'s {{Event/type}} is not <code>[=fencedtreeclick=]</code>
   
   1. If [=this=]'s [=relevant global object=] does not have [=transient activation=], then return.
 
   1. [=Consume user activation=] for [=this=]'s [=relevant global object=].
 
-  1. [=Fire an event=] named "fencedtreeclick" at |navigable|'s 
+  1. [=Fire an event=] named <code>[=fencedtreeclick=]</code> at |navigable|'s 
      [=fenced navigable container=]. Initialize the event's {{Event/bubbles}} and {{Event/cancelable}}
      attributes to `true`. When running the 
      <a href="https://dom.spec.whatwg.org/#inner-event-creation-steps">inner event creation steps</a>, 
@@ -3001,11 +2999,12 @@ navigables=] algorithm with [=inclusive-dn-unfenced|unfenced=] set to true.
 
 <h3 id=events>Events</h3>
 
-The {{Fence/notifyEvent}} method of the {{Fence}} interface introduces a new event type, `fencedtreeclick`.
+The {{Fence/notifyEvent}} method of the {{Fence}} interface introduces a new event type, <code><dfn>fencedtreeclick</dfn></code>.
 
-The [=event handlers on elements, Document objects, and Window objects=] section of [[HTML]] is modified to 
-include a new row. The [=event handler=] name is `onfencedtreeclick`, and the [=event handler event type=] is
-`fencedtreeclick`.
+The <a href="https://html.spec.whatwg.org/multipage/webappapis.html#event-handlers-on-elements,-document-objects,-and-window-objects">
+event handlers on elements, Document objects, and Window objects</a> section of [[HTML]] is modified to 
+include a new row. The [=event handler=] name is <code>onfencedtreeclick</code>, and the [=event handler event type=] is
+<code>[=fencedtreeclick=]</code>.
 
 The {{GlobalEventHandlers}} interface is modified as follows:
 

--- a/spec.bs
+++ b/spec.bs
@@ -1859,6 +1859,8 @@ Several APIs specific to fenced frames are defined on the {{Fence}} interface.
   1. [=Queue a global task=] on the [=DOM manipulation task source=] given |parentNavigable|'s     
      [=navigable/active window=] to fire a "<code>[=fencedtreeclick=]</code>" event:
   
+     1. Perform the [=activation notification=] steps.
+
      1. [=Fire an event=] named "<code>[=fencedtreeclick=]</code>" at |navigable|'s 
         [=fenced navigable container=]. Initialize the event's {{Event/bubbles}} and {{Event/cancelable}} attributes to `true`. When running the 
         <a href="https://dom.spec.whatwg.org/#inner-event-creation-steps">inner event creation steps</a>, set the <var ignore=''>time</var> to a user-agent-defined value that is consistent across all invocations of this method.

--- a/spec.bs
+++ b/spec.bs
@@ -1856,7 +1856,7 @@ Several APIs specific to fenced frames are defined on the {{Fence}} interface.
 
   1. If [=this=]'s {{Document}} is not [=Document/fully active=], then return.
 
-  1. Let |navigable| be [=this=]'s [=relevant global object=]'s [=navigable=].
+  1. Let |navigable| be [=this=]'s [=relevant global object=]'s [=Window/navigable=].
   
   1. If any of the following conditions are met, throw a {{SecurityError}} {{DOMException}}:
 
@@ -3024,11 +3024,12 @@ modified to include a new row.
   </thead>
   <tbody>
     <tr>
-      <td><dfn export><code>fencedtreeclick</code></dfn></td> 
+      <td><dfn><code>fencedtreeclick</code></dfn></td> 
       <td>{{Event}}</td> 
       <td>Elements</td>
       <td>
-        Fired at a <{fencedframe}> element when its contained content calls {{Fence/notifyEvent}}
+        Fired at a <{fencedframe}> element asynchronously after its
+        [=fenced navigable container/fenced navigable=]'s {{Document}} calls {{Fence/notifyEvent()}}
       </td>
     </tr>
   </tbody>
@@ -3049,7 +3050,7 @@ to include a new row. The [=event handler=] name is <code>onfencedtreeclick</cod
   </thead>
   <tbody>
     <tr>
-      <td><dfn export><code>onfencedtreeclick</code></dfn></td>
+      <td><dfn><code>onfencedtreeclick</code></dfn></td>
       <td><code>[=fencedtreeclick=]</code></td>
     </tr>
   </tbody>


### PR DESCRIPTION
This adds event handlers for `onfencedtreeclick`, and describes the algorithm for `window.fence.notifyEvent()`, which fires `fencedtreeclick` events from the fenced frame's document to the `HTMLFencedFrameElement` in the embedder.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/VergeA/fenced-frame/pull/156.html" title="Last updated on Oct 21, 2024, 4:40 PM UTC (160aadd)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/fenced-frame/156/73d37f8...VergeA:160aadd.html" title="Last updated on Oct 21, 2024, 4:40 PM UTC (160aadd)">Diff</a>