### PR TITLE
Add definitions for event reporting opt in headers

### DIFF
--- a/spec.bs
+++ b/spec.bs
@@ -2498,19 +2498,22 @@ container/fenced navigable=] will fail, as outlined in [[#navigation-patch]].
 <h4 id=allow-automatic-beacons>The
 \`<a http-header><code>Allow-Fenced-Frame-Automatic-Beacons</code></a>\` HTTP response header</h4>
 
-A {{Document}} that is not [=same origin=] with its [=Document/browsing context=]'s [=fenced frame
-config instance=]'s [=fenced frame config instance/mapped url=] can opt into sending an automatic
-beacon when it navigates by using the <dfn
-http-header><code>Allow-Fenced-Frame-Automatic-Beacons</code></dfn> HTTP response header. This
-header is a [=structured header=] whose value must be either the [=string=] "true" or "false".
+Serving a document [=resource=] that gets loaded into a {{Document}} that is not [=same origin=]
+with its [=Document/browsing context=]'s [=fenced frame config instance=]'s [=fenced frame config
+instance/mapped url=] with the <dfn
+http-header><code>Allow-Fenced-Frame-Automatic-Beacons</code></dfn> HTTP response header can
+automatically opt in the {{Document}} to having automatic beacon events trigger when it performs
+navigations. This header is a [=structured header=] whose value must be either the [=string=] "true"
+or "false".
 
 <h4 id=allow-cross-origin-reporting>The
 \`<a http-header><code>Allow-Cross-Origin-Event-Reporting</code></a>\` HTTP response header</h4>
 
-A {{Document}} loaded from a [=fenced frame config instance=] can opt into its cross-origin [=child
-navigables=]' {{Document}}s sending {{Fence/reportEvent()}} beacons by using the <dfn
-http-header><code>Allow-Cross-Origin-Event-Reporting</code></dfn> HTTP response header. This header
-is a [=structured header=] whose value must be either the [=string=] "true" or "false".
+Serving a document [=resource=] that gets loaded into a <{fencedframe}> by a [=fenced frame config
+instance=] with the <dfn http-header><code>Allow-Cross-Origin-Event-Reporting</code></dfn> HTTP
+response header can automatically opt in the {{Document}}'s cross-origin [=child navigables=]
+to be able to send {{Fence/reportEvent()}} beacons. This header is a [=structured header=] whose
+value must be either the [=string=] "true" or "false".
 
 <h4 id=coop-coep>COOP, COEP, and cross-origin isolation</h4>
 

--- a/spec.bs
+++ b/spec.bs
@@ -2498,22 +2498,22 @@ container/fenced navigable=] will fail, as outlined in [[#navigation-patch]].
 <h4 id=allow-automatic-beacons>The
 \`<a http-header><code>Allow-Fenced-Frame-Automatic-Beacons</code></a>\` HTTP response header</h4>
 
-Serving a document [=resource=] that gets loaded into a {{Document}} that is not [=same origin=]
-with its [=Document/browsing context=]'s [=fenced frame config instance=]'s [=fenced frame config
+Serving a document resource that gets loaded into a {{Document}} that is not [=same origin=] with
+its [=Document/browsing context=]'s [=fenced frame config instance=]'s [=fenced frame config
 instance/mapped url=] with the <dfn
-http-header><code>Allow-Fenced-Frame-Automatic-Beacons</code></dfn> HTTP response header can
-automatically opt in the {{Document}} to having automatic beacon events trigger when it performs
+http-header><code>Allow-Fenced-Frame-Automatic-Beacons</code></dfn> HTTP response header
+automatically opts in the {{Document}} to having automatic beacon events trigger when it performs
 navigations. This header is a [=structured header=] whose value must be either the [=string=] "true"
 or "false".
 
 <h4 id=allow-cross-origin-reporting>The
 \`<a http-header><code>Allow-Cross-Origin-Event-Reporting</code></a>\` HTTP response header</h4>
 
-Serving a document [=resource=] that gets loaded into a <{fencedframe}> by a [=fenced frame config
+Serving a document resource that gets loaded into a <{fencedframe}> by a [=fenced frame config
 instance=] with the <dfn http-header><code>Allow-Cross-Origin-Event-Reporting</code></dfn> HTTP
-response header can automatically opt in the {{Document}}'s cross-origin [=child navigables=]
-to be able to send {{Fence/reportEvent()}} beacons. This header is a [=structured header=] whose
-value must be either the [=string=] "true" or "false".
+response header automatically opts in the {{Document}}'s cross-origin [=child navigables=] to be
+able to send {{Fence/reportEvent()}} beacons. This header is a [=structured header=] whose value
+must be either the [=string=] "true" or "false".
 
 <h4 id=coop-coep>COOP, COEP, and cross-origin isolation</h4>
 

--- a/spec.bs
+++ b/spec.bs
@@ -2495,6 +2495,24 @@ container/fenced navigable=] will fail, as outlined in [[#navigation-patch]].
 
 </div>
 
+<h4 id=allow-automatic-beacons>The
+\`<a http-header><code>Allow-Fenced-Frame-Automatic-Beacons</code></a>\` HTTP response header</h4>
+
+A {{Document}} that is not [=same origin=] with its [=fenced frame config instance=]'s [=fenced
+frame config instance/mapped url=] can opt into sending an automatic beacon when it navigates by
+using the <dfn http-header><code>Allow-Fenced-Frame-Automatic-Beacons</code></dfn> HTTP response
+header. This header is a [=structured header=] whose value must be either the [=string=] "true" or
+"false".
+
+<h4 id=allow-cross-origin-reporting>The
+\`<a http-header><code>Allow-Cross-Origin-Event-Reporting</code></a>\` HTTP response header</h4>
+
+A {{Document}} that is not [=same origin=] with its [=fenced frame config instance=]'s [=fenced
+frame config instance/mapped url=] can opt into cross-origin {{Document}}s in [=child navigables=]
+sending {{Fence/reportEvent()}} beacons by using the <dfn
+http-header><code>Allow-Cross-Origin-Event-Reporting</code></dfn> HTTP response header. This header
+is a [=structured header=] whose value must be either the [=string=] "true" or "false".
+
 <h4 id=coop-coep>COOP, COEP, and cross-origin isolation</h4>
 
 Outside of this specification, the \`<a http-header><code>Cross-Origin-Opener-Policy</code></a>\`
@@ -2780,10 +2798,10 @@ content in the <{fencedframe}> or its embedder, exactly one of two things will h
        [[#bcg-swap]].
 
     1. Set |navigationParams|'s [=navigation params/fenced frame config instance=]'s [=fenced frame
-       config/cross-origin reporting allowed=] to the result of running [=header list/get a
+       config/cross-origin reporting allowed=] to true if the result of running [=header list/get a
        structured field value=] on |navigationParams|'s [=navigation params/response=]'s
-       [=response/header list=] given "<code>Allow-Cross-Origin-Event-Reporting</code>" and
-       "`item`".
+       [=response/header list=] given "[:Allow-Cross-Origin-Event-Reporting</code>:]" and
+       "`item`" is "true", false otherwise.
 
     1. Set |browsingContext|'s [=browsing context/fenced frame config instance=] to
        |navigationParams|'s [=navigation params/fenced frame config instance=].
@@ -2792,11 +2810,11 @@ content in the <{fencedframe}> or its embedder, exactly one of two things will h
 
   10. Let |automaticBeaconsAllowed| be the result of running [=header list/get a structured field
       value=] on |navigationParams|'s [=navigation params/response=]'s [=response/header list=]
-      given "<code>Allow-Fenced-Frame-Automatic-Beacons</code>" and "`item`".
+      given "[:Allow-Fenced-Frame-Automatic-Beacons:]" and "`item`".
   
   Further rewrite step 10 (now step 12) to return a new {{Document}} with an additional parameter:
   : [=Document/automatic beacons allowed=]
-  :: |automaticBeaconsAllowed|
+  :: true if |automaticBeaconsAllowed| is "true", false otherwise.
 </div>
 
 <span class=XXX>TODO: Call the [=fenced frame config instance/on navigate callback=] at the

--- a/spec.bs
+++ b/spec.bs
@@ -2502,19 +2502,18 @@ container/fenced navigable=] will fail, as outlined in [[#navigation-patch]].
 Serving a document resource that gets loaded into a {{Document}} that is not [=same origin=] with
 its [=Document/browsing context=]'s [=fenced frame config instance=]'s [=fenced frame config
 instance/mapped url=] with the <dfn
-http-header><code>Allow-Fenced-Frame-Automatic-Beacons</code></dfn> HTTP response header
-automatically opts in the {{Document}} to having automatic beacon events trigger when it performs
-navigations. This header is a [=structured header=] whose value must be a [=structured
-header/boolean=].
+http-header><code>Allow-Fenced-Frame-Automatic-Beacons</code></dfn> HTTP response header opts in the
+{{Document}} to having automatic beacon events trigger when it performs navigations. This header is
+a [=structured header=] whose value must be a [=structured header/boolean=].
 
 <h4 id=allow-cross-origin-reporting>The
 \`<a http-header><code>Allow-Cross-Origin-Event-Reporting</code></a>\` HTTP response header</h4>
 
 Serving a document resource that gets loaded into a <{fencedframe}> by a [=fenced frame config
 instance=] with the <dfn http-header><code>Allow-Cross-Origin-Event-Reporting</code></dfn> HTTP
-response header automatically opts in the {{Document}}'s cross-origin [=child navigables=] to be
-able to send {{Fence/reportEvent()}} beacons. This header is a [=structured header=] whose value
-must be a [=structured header/boolean=].
+response header opts in the {{Document}}'s cross-origin [=child navigables=] to be able to send
+{{Fence/reportEvent()}} beacons. This header is a [=structured header=] whose value must be a
+[=structured header/boolean=].
 
 <h4 id=coop-coep>COOP, COEP, and cross-origin isolation</h4>
 

--- a/spec.bs
+++ b/spec.bs
@@ -2498,17 +2498,17 @@ container/fenced navigable=] will fail, as outlined in [[#navigation-patch]].
 <h4 id=allow-automatic-beacons>The
 \`<a http-header><code>Allow-Fenced-Frame-Automatic-Beacons</code></a>\` HTTP response header</h4>
 
-A {{Document}} that is not [=same origin=] with its [=fenced frame config instance=]'s [=fenced
-frame config instance/mapped url=] can opt into sending an automatic beacon when it navigates by
-using the <dfn http-header><code>Allow-Fenced-Frame-Automatic-Beacons</code></dfn> HTTP response
-header. This header is a [=structured header=] whose value must be either the [=string=] "true" or
-"false".
+A {{Document}} that is not [=same origin=] with its [=Document/browsing context=]'s [=fenced frame
+config instance=]'s [=fenced frame config instance/mapped url=] can opt into sending an automatic
+beacon when it navigates by using the <dfn
+http-header><code>Allow-Fenced-Frame-Automatic-Beacons</code></dfn> HTTP response header. This
+header is a [=structured header=] whose value must be either the [=string=] "true" or "false".
 
 <h4 id=allow-cross-origin-reporting>The
 \`<a http-header><code>Allow-Cross-Origin-Event-Reporting</code></a>\` HTTP response header</h4>
 
-A {{Document}} loaded with a [=fenced frame config instance=] can opt into cross-origin
-{{Document}}s in [=child navigables=] sending {{Fence/reportEvent()}} beacons by using the <dfn
+A {{Document}} loaded from a [=fenced frame config instance=] can opt into its cross-origin [=child
+navigables=]' {{Document}}s sending {{Fence/reportEvent()}} beacons by using the <dfn
 http-header><code>Allow-Cross-Origin-Event-Reporting</code></dfn> HTTP response header. This header
 is a [=structured header=] whose value must be either the [=string=] "true" or "false".
 

--- a/spec.bs
+++ b/spec.bs
@@ -2507,9 +2507,8 @@ header. This header is a [=structured header=] whose value must be either the [=
 <h4 id=allow-cross-origin-reporting>The
 \`<a http-header><code>Allow-Cross-Origin-Event-Reporting</code></a>\` HTTP response header</h4>
 
-A {{Document}} that is not [=same origin=] with its [=fenced frame config instance=]'s [=fenced
-frame config instance/mapped url=] can opt into cross-origin {{Document}}s in [=child navigables=]
-sending {{Fence/reportEvent()}} beacons by using the <dfn
+A {{Document}} loaded with a [=fenced frame config instance=] can opt into cross-origin
+{{Document}}s in [=child navigables=] sending {{Fence/reportEvent()}} beacons by using the <dfn
 http-header><code>Allow-Cross-Origin-Event-Reporting</code></dfn> HTTP response header. This header
 is a [=structured header=] whose value must be either the [=string=] "true" or "false".
 

--- a/spec.bs
+++ b/spec.bs
@@ -218,6 +218,7 @@ spec: RFC8941; urlPrefix: https://www.rfc-editor.org/rfc/rfc8941.html
     text: structured header; url: #section-1
     for: structured header
       text: token; url: name-tokens
+      text: boolean; url: boolean
 spec: permissions-policy; urlPrefix: https://w3c.github.io/webappsec-permissions-policy
   type: dfn
     text: ASCII-serialized policy directive; url: serialized-policy-directive
@@ -2503,8 +2504,8 @@ its [=Document/browsing context=]'s [=fenced frame config instance=]'s [=fenced 
 instance/mapped url=] with the <dfn
 http-header><code>Allow-Fenced-Frame-Automatic-Beacons</code></dfn> HTTP response header
 automatically opts in the {{Document}} to having automatic beacon events trigger when it performs
-navigations. This header is a [=structured header=] whose value must be either the [=string=] "true"
-or "false".
+navigations. This header is a [=structured header=] whose value must be a [=structured
+header/boolean=].
 
 <h4 id=allow-cross-origin-reporting>The
 \`<a http-header><code>Allow-Cross-Origin-Event-Reporting</code></a>\` HTTP response header</h4>
@@ -2513,7 +2514,7 @@ Serving a document resource that gets loaded into a <{fencedframe}> by a [=fence
 instance=] with the <dfn http-header><code>Allow-Cross-Origin-Event-Reporting</code></dfn> HTTP
 response header automatically opts in the {{Document}}'s cross-origin [=child navigables=] to be
 able to send {{Fence/reportEvent()}} beacons. This header is a [=structured header=] whose value
-must be either the [=string=] "true" or "false".
+must be a [=structured header/boolean=].
 
 <h4 id=coop-coep>COOP, COEP, and cross-origin isolation</h4>
 
@@ -2800,10 +2801,9 @@ content in the <{fencedframe}> or its embedder, exactly one of two things will h
        [[#bcg-swap]].
 
     1. Set |navigationParams|'s [=navigation params/fenced frame config instance=]'s [=fenced frame
-       config/cross-origin reporting allowed=] to true if the result of running [=header list/get a
+       config/cross-origin reporting allowed=] to the result of running [=header list/get a
        structured field value=] on |navigationParams|'s [=navigation params/response=]'s
-       [=response/header list=] given "[:Allow-Cross-Origin-Event-Reporting</code>:]" and
-       "`item`" is "true", false otherwise.
+       [=response/header list=] given [:Allow-Cross-Origin-Event-Reporting:] and "`item`".
 
     1. Set |browsingContext|'s [=browsing context/fenced frame config instance=] to
        |navigationParams|'s [=navigation params/fenced frame config instance=].
@@ -2812,11 +2812,11 @@ content in the <{fencedframe}> or its embedder, exactly one of two things will h
 
   10. Let |automaticBeaconsAllowed| be the result of running [=header list/get a structured field
       value=] on |navigationParams|'s [=navigation params/response=]'s [=response/header list=]
-      given "[:Allow-Fenced-Frame-Automatic-Beacons:]" and "`item`".
+      given [:Allow-Fenced-Frame-Automatic-Beacons:] and "`item`".
   
   Further rewrite step 10 (now step 12) to return a new {{Document}} with an additional parameter:
   : [=Document/automatic beacons allowed=]
-  :: true if |automaticBeaconsAllowed| is "true", false otherwise.
+  :: |automaticBeaconsAllowed|.
 </div>
 
 <span class=XXX>TODO: Call the [=fenced frame config instance/on navigate callback=] at the


### PR DESCRIPTION
This issue was brought up in https://github.com/WICG/fenced-frame/issues/158.

This PR adds official definitions for the `Allow-Fenced-Frame-Automatic-Beacons` and the `Allow-Cross-Origin-Event-Reporting` response headers that are used for cross-origin opt in for their respective features.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/WICG/fenced-frame/pull/159.html" title="Last updated on May 21, 2024, 12:04 PM UTC (bff5d37)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/fenced-frame/159/dbb22ca...bff5d37.html" title="Last updated on May 21, 2024, 12:04 PM UTC (bff5d37)">Diff</a>