### PR TITLE
Spec: fix 'src' permissions policy allowlist.

### DIFF
--- a/spec.bs
+++ b/spec.bs
@@ -227,6 +227,10 @@ spec: permissions-policy; urlPrefix: https://w3c.github.io/webappsec-permissions
     text: the special value *; url: the-special-value
     text: permissions policy; url: permissions-policy
     text: policy directive; url: policy-directive
+    for: allowlist
+      text: src-origin; url: src-origin
+    for: declared policy
+      text: declarations; url: declared-policy-declarations
     for: permissions policy
       text: declared policy; url: permissions-policy-declared-policy
       text: inherited policy; url: permissions-policy-inherited-policy
@@ -2890,9 +2894,9 @@ content in the <{fencedframe}> or its embedder, exactly one of two things will h
 
 <div algorithm=create-and-initialize-document-patch>
   Modify [[!HTML]]'s [=create and initialize a Document object=] algorithm to insert one step after
-  step 2 that reads:
+  step 3 that reads:
 
-  3. If |navigationParams|'s [=navigation params/fenced frame config instance=] is not null:
+  4. If |navigationParams|'s [=navigation params/fenced frame config instance=] is not null:
 
     1. [=Assert=]: |browsingContext| does not equal |navigationParams|'s [=navigation
        params/navigable=]'s [=navigable/active browsing context=].
@@ -2908,6 +2912,10 @@ content in the <{fencedframe}> or its embedder, exactly one of two things will h
 
     1. Set |browsingContext|'s [=browsing context/fenced frame config instance=] to
        |navigationParams|'s [=navigation params/fenced frame config instance=].
+
+    1. Set |permissionsPolicy| to the result of running [=substitute the src-origin allowlist in
+       permissions declarations=] given |permissionsPolicy| and |navigationParams|'s [=navigation
+       params/fenced frame config instance=]'s [=fenced frame config/mapped url=]'s [=url/origin=].
 
   Add a new step after step 9 that reads:
 
@@ -3409,7 +3417,26 @@ algorithms to achieve the outcomes described in the above explanatory content.
      and |origin| is [=same origin=] with |document|'s origin, return "Enabled".
 </div>
 
+<div algorithm>
+  To <dfn>substitute the src-origin allowlist in permissions declarations</dfn> given a
+  [=permissions policy=] |permissionsPolicy| and an [=url/origin=] |originToSubstitute|, run these
+  steps:
+
+  1. [=list/For each=] |feature| → |allowlist| of |permissionsPolicy|'s [=permissions
+     policy/declared policy=]'s [=declared policy/declarations=]:
+
+     1. If |allowlist|'s [=allowlist/src-origin=] is not null:
+        
+        1. Set |allowlist|'s [=allowlist/src-origin=] to |originToSubstitute|.
+
+        1. Set |permissionsPolicy|'s [=permissions policy/declared policy=]'s [=declared
+           policy/declarations=][|feature|] to |allowlist|.
+
+  1. Return |permissionsPolicy|.
+</div>
+
 <wpt>
+  /fenced-frame/allow-attribute-src.https.html
   /fenced-frame/default-enabled-features-allow-all.https.html
   /fenced-frame/default-enabled-features-allow-none.https.html
   /fenced-frame/default-enabled-features-allow-self.https.html


### PR DESCRIPTION
The 'src' allowlist is a feature unique to iframes and fenced frames that, if set, only allows a given feature for the origin loaded in the src/config attribute. This is calculated in the embedder. However, when loading a fenced frame with a fenced frame config, that origin is opaque to the embedder but transparent to the inner content. This causes a mismatch where the inner content is told to only allow a feature for an opaque 'src', but it will see it was navigated to a transparent URL. It will then disallow the feature, even though it is navigated to the FencedFrameConfig installed in the "src" or "config" attribute.

The mismatch is fixed by recalculating the document's permissions policy allowlists once the mapped URL is known. More specifically, this is done during the [create and initialize a Document object](https://html.spec.whatwg.org/multipage/document-lifecycle.html#initialise-the-document-object) algorithm right after the |permissionsPolicy| is first loaded into the document. Any allowlists that match the [opaque 'src'](https://w3c.github.io/webappsec-permissions-policy/#src-origin) (a value set by the embedder that doesn't and shouldn't know the final navigated URL) are replaced with the document's fenced frame config's mapped URL's origin.