### PR TITLE
Set attribution reporting headers even if there's no supported registrar

### DIFF
--- a/spec.bs
+++ b/spec.bs
@@ -882,9 +882,8 @@ A <dfn for=fencedframetype>destination event</dfn> is either a
 
      1. Set |destination url| to |destination map|[|eventType|].
 
-    1. If |event|'s [=destination enum event/attributionReportingEnabled=] is true and the result
-       of [=getting supported registrars=] is not [=list/is empty|empty=] and |event|'s
-       [=destination enum event/attributionReportingContextOrigin=] [=check if an origin is suitable|is suitable=]:
+    1. If |event|'s [=destination enum event/attributionReportingEnabled=] is true
+        and |event|'s [=destination enum event/attributionReportingContextOrigin=] [=check if an origin is suitable|is suitable=]:
 
         1. If |event|'s {{FenceEvent/eventType}} matches one of the [=fencedframetype/automatic
            beacon event type=] values, set |attributionReportingEligibility| to


### PR DESCRIPTION
This would be beneficial to tell the reporting origin that attribution reporting is not supported, as opposed to letting it assume it can still register triggers.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/linnan-github/fenced-frame/pull/177.html" title="Last updated on Aug 15, 2024, 5:25 PM UTC (9851b18)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/fenced-frame/177/c799ffe...linnan-github:9851b18.html" title="Last updated on Aug 15, 2024, 5:25 PM UTC (9851b18)">Diff</a>