### PR TITLE
Remove unused config size attributes

### DIFF
--- a/spec.bs
+++ b/spec.bs
@@ -666,9 +666,9 @@ boundary, which can allow for colluding parties to join cross-site data and buil
 user. To prevent that, the ad auction API [=construct a pending fenced frame config|constructs=] a
 [=fenced frame config=] whose underlying [=fenced frame config/mapped url|URL=] is opaque to the
 embedding context. The [=fenced frame config=] is also constructed with restrictions on what the
-[=fenced frame config/container size=] and [=fenced frame config/content size=] of the frame must be
-and what the [=fenced frame config/effective enabled permissions|permissions policy=] of the frame
-must be, as those can be used as fingerprinting vectors.
+[=fenced frame config/content size=] of the frame must be and what the [=fenced frame config/
+effective enabled permissions|permissions policy=] of the frame must be, as those can be used as 
+fingerprinting vectors.
 
 Displaying a personalized payment button:
 
@@ -1072,9 +1072,6 @@ A <dfn export>fenced frame config</dfn> is a [=struct=] with the following [=str
     : <dfn for="mapped url">visibility</dfn>
     :: a [=fencedframeconfig/visibility=]
 
-  : <dfn>container size</dfn>
-  :: null, or a [=fencedframetype/size=]
-
   : <dfn>content size</dfn>
   :: null, or a [=struct=] with the following [=struct/items=]:
     : <dfn for="content size">value</dfn>
@@ -1171,9 +1168,6 @@ A <dfn export>fenced frame config instance</dfn> is a [=struct=] with the follow
   : <dfn>mapped url</dfn>
   :: a [=URL=]
 
-  : <dfn>container size</dfn>
-  :: null, or a [=fencedframetype/size=]
-
   : <dfn>content size</dfn>
   :: null, or a [=fencedframetype/size=]
 
@@ -1218,9 +1212,6 @@ A <dfn export>fenced frame config instance</dfn> is a [=struct=] with the follow
 
     : [=fenced frame config instance/mapped url=]
     :: |config|'s [=fenced frame config/mapped url=]'s [=mapped url/value=]
-
-    : [=fenced frame config instance/container size=]
-    :: |config|'s [=fenced frame config/container size=]
 
     : [=fenced frame config instance/content size=]
     :: |config|'s [=fenced frame config/content size=] if null, otherwise |config|'s [=fenced frame
@@ -1324,12 +1315,6 @@ maps to an internal [=fenced frame config=] [=struct=].
   [Exposed=Window, Serializable]
   interface FencedFrameConfig {
     constructor(USVString url);
-    
-    readonly attribute FencedFrameConfigSize? containerWidth;
-    readonly attribute FencedFrameConfigSize? containerHeight;
-    readonly attribute FencedFrameConfigSize? contentWidth;
-    readonly attribute FencedFrameConfigSize? contentHeight;
-
     undefined setSharedStorageContext(DOMString contextString);
   };
 </pre>
@@ -1339,10 +1324,6 @@ Each {{FencedFrameConfig}} has:
  * A <dfn for=fencedframeconfig>url</dfn>, a [=URL=], failure, or null, initially null
  * A <dfn for=fencedframeconfig>urn</dfn>, a [=urn uuid=]
  * A <dfn for=fencedframeconfig>sharedStorageContext</dfn>, a [=string=]
- * A <dfn for=fencedframeconfig>containerWidth</dfn>, a {{FencedFrameConfigSize}} or null
- * A <dfn for=fencedframeconfig>containerHeight</dfn>, a {{FencedFrameConfigSize}} or null
- * A <dfn for=fencedframeconfig>contentWidth</dfn>, a {{FencedFrameConfigSize}} or null
- * A <dfn for=fencedframeconfig>contentHeight</dfn>, a {{FencedFrameConfigSize}} or null
 
 Note: A config's [=fencedframeconfig/url=] is only null if a [=fencedframeconfig/urn=] is supplied.
 
@@ -1355,26 +1336,6 @@ Note: A config's [=fencedframeconfig/url=] is only null if a [=fencedframeconfig
   1. Set |config|'s [=fencedframeconfig/url=] to the result of running the [=URL parser=] on |url|.
 
   1. Return |config|.
-</div>
-
-<div algorithm="containerWidth getter">
-  The {{FencedFrameConfig/containerWidth}} IDL attribute getter steps are to return [=this=]'s
-  [=fencedframeconfig/containerWidth=].
-</div>
-
-<div algorithm="containerHeight getter">
-  The {{FencedFrameConfig/containerHeight}} IDL attribute getter steps are to return [=this=]'s
-  [=fencedframeconfig/containerHeight=].
-</div>
-
-<div algorithm="contentWidth getter">
-  The {{FencedFrameConfig/contentWidth}} IDL attribute getter steps are to return [=this=]'s
-  [=fencedframeconfig/contentWidth=].
-</div>
-
-<div algorithm="contentHeight getter">
-  The {{FencedFrameConfig/contentHeight}} IDL attribute getter steps are to return [=this=]'s
-  [=fencedframeconfig/contentHeight=].
 </div>
 
 <div algorithm>
@@ -1394,20 +1355,6 @@ Note: A config's [=fencedframeconfig/url=] is only null if a [=fencedframeconfig
 
   1. Set |serialized|.\[[SharedStorageContext]] to |value|'s [=fencedframeconfig/
      sharedStorageContext=].
-
-  1. Set |serialized|.\[[ContainerWidth]] to |value|'s [=fencedframeconfig/
-     containerWidth=].
-
-  1. Set |serialized|.\[[ContainerHeight]] to |value|'s [=fencedframeconfig/
-     containerHeight=].
-
-  1. Set |serialized|.\[[ContentWidth]] to |value|'s [=fencedframeconfig/
-     contentWidth=].
-
-  1. Set |serialized|.\[[ContentHeight]] to |value|'s [=fencedframeconfig/
-     contentHeight=].
-
-
 </div>
 
 <div algorithm="FencedFrameConfig deserializer">
@@ -1420,15 +1367,6 @@ Note: A config's [=fencedframeconfig/url=] is only null if a [=fencedframeconfig
 
   1. Initialize |value|'s [=fencedframeconfig/sharedStorageContext=] to
      |serialized|.\[[SharedStorageContext]].
-
-  1. Initialize |value|'s [=fencedframeconfig/containerWidth=] to |serialized|.\[[ContainerWidth]].
-
-  1. Initialize |value|'s [=fencedframeconfig/containerHeight=] to
-     |serialized|.\[[ContainerHeight]].
-
-  1. Initialize |value|'s [=fencedframeconfig/contentWidth=] to |serialized|.\[[ContentWidth]].
-
-  1. Initialize |value|'s [=fencedframeconfig/contentHeight=] to |serialized|.\[[ContentHeight]].
 </div>
 
 Note: To help with ease of adoption,
@@ -1808,26 +1746,6 @@ Several APIs specific to fenced frames are defined on the {{Fence}} interface.
 
         : [=fencedframeconfig/sharedStorageContext=]
         :: |config|'s [=fenced frame config/embedder shared storage context=]
-
-        : [=fencedframeconfig/containerWidth=]
-        :: null if |config|'s [=fenced frame config/container size=] is null, otherwise |config|'s
-           [=fenced frame config/container size=]'s [=size/width=]
-
-        : [=fencedframeconfig/containerHeight=]
-        :: null if |config|'s [=fenced frame config/container size=] is null, otherwise |config|'s
-           [=fenced frame config/container size=]'s [=size/height=]
-
-        : [=fencedframeconfig/contentWidth=]
-        :: null if |config|'s [=fenced frame config/content size=] is null, the `"opaque"`
-           {{OpaqueProperty}} if |config|'s [=fenced frame config/content size=]'s [=content
-           size/visibility=] is [=visibility/opaque=], otherwise |config|'s [=fenced frame
-           config/content size=]'s [=size/width=]
-
-        : [=fencedframeconfig/contentHeight=]
-        :: null if |config|'s [=fenced frame config/content size=] is null, the `"opaque"`
-           {{OpaqueProperty}} if |config|'s [=fenced frame config/content size=]'s [=content
-           size/visibility=] is [=visibility/opaque=], otherwise |config|'s [=fenced frame
-           config/content size=]'s [=size/height=]
 
      1. [=list/Append=] |newConfig| to |results|.
 

--- a/spec.bs
+++ b/spec.bs
@@ -1309,9 +1309,6 @@ maps to an internal [=fenced frame config=] [=struct=].
 <pre class=idl>
   enum OpaqueProperty {"opaque"};
 
-  typedef (unsigned long or OpaqueProperty) FencedFrameConfigSize;
-  typedef USVString FencedFrameConfigURL;
-
   [Exposed=Window, Serializable]
   interface FencedFrameConfig {
     constructor(USVString url);


### PR DESCRIPTION
The IDL containerWidth, containerHeight, contentWidth, and contentHeight attributes not actually implemented in Chromuim, so we should remove them.

Additionally, the internal fenced frame config struct does not implement container size, only content size. So we should remove that as well.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/VergeA/fenced-frame/pull/182.html" title="Last updated on Aug 29, 2024, 5:37 PM UTC (7a51c0e)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/fenced-frame/182/c799ffe...VergeA:7a51c0e.html" title="Last updated on Aug 29, 2024, 5:37 PM UTC (7a51c0e)">Diff</a>