### PR TITLE
[Spec] Fix navigation from the default constructor not installing a fenced frame config.

### DIFF
--- a/spec.bs
+++ b/spec.bs
@@ -1454,9 +1454,9 @@ Note: A config's [=fencedframeconfig/url=] is only null if a [=fencedframeconfig
   |value|, |serialized|, and |forStorage| are:
 
   1. If |forStorage| is true, then throw a {{DataCloneError}} {{DOMException}}.
-
-  1. Set |serialized|.\[[Url]] to |value|'s [=fencedframeconfig/url=].
   
+  1. Set |serialized|.\[[Url]] to |value|'s [=fencedframeconfig/url=].
+
   1. Set |serialized|.\[[Urn]] to |value|'s [=fencedframeconfig/urn=].
 
   1. Set |serialized|.\[[SharedStorageContext]] to |value|'s [=fencedframeconfig/
@@ -1480,7 +1480,7 @@ Note: A config's [=fencedframeconfig/url=] is only null if a [=fencedframeconfig
 <div algorithm="FencedFrameConfig deserializer">
   Their [=deserialization steps=], given |serialized|, |value|, and <var ignore> targetRealm</var>
   are:
-  
+
   1. Initialize |value|'s [=fencedframeconfig/url=] to |serialized|.\[[Url]].
   
   1. Initialize |value|'s [=fencedframeconfig/urn=] to |serialized|.\[[Urn]].

--- a/spec.bs
+++ b/spec.bs
@@ -2892,8 +2892,9 @@ CORP violation report=] algorithm, as leaving it unfenced may cause a privacy le
 
       1. Run steps in |config|'s [=fenced frame config/on navigate callback=].
   
-    1. If |navigable| is a [=fenced navigable container/fenced navigable=], and
-       <var ignore>sourceDocument</var>'s [=node navigable=] is not |navigable|:
+    1. If |navigable| is a [=fenced navigable container/fenced navigable=] and
+       <var ignore>sourceDocument</var>'s [=node navigable=] is in |navigable|'s
+       [=navigable/active document=]'s [=Document/ancestor navigables=]:
 
       1. Let |config| be a new [=fenced frame config=] with the following [=struct/items=]:
 

--- a/spec.bs
+++ b/spec.bs
@@ -2436,18 +2436,6 @@ in the [[#nested-traversables-intro]].
   1. Return |navigables|.
 </div>
 
-<div algorithm="inclusive-ancestor-navigables-patch">
-  Modify the [=Document/inclusive ancestor navigables=] algorithm to take a new optional
-  [=boolean=] argument <var><dfn lt="inclusive-an-unfenced">unfenced</dfn></var> that defaults to
-  false.
-
-  Further rewrite step 1 of this algorithm to:
-
-  1. Let <var ignore>navigables</var> be <var ignore>document</var>'s [=Document/ancestor
-     navigables=] with [=an-unfenced|unfenced=] set to
-     <var>[=inclusive-an-unfenced|unfenced=]</var>.
-</div>
-
 <div algorithm="ancestor-navigables-patch">
   Modify the [=Document/ancestor navigables=] algorithm to take a new optional [=boolean=]
   argument <dfn lt="an-unfenced">unfenced</dfn> that defaults to false, and rewrite the algorithm

--- a/spec.bs
+++ b/spec.bs
@@ -2893,12 +2893,14 @@ CORP violation report=] algorithm, as leaving it unfenced may cause a privacy le
     1. If |url| is a [=urn uuid=] and |navigable| is a [=fenced navigable container/fenced
        navigable=]:
 
-       Issue: If a fenced frame generates a FencedFrameConfig using a config-generating API, and
-       then correctly guesses the urn:uuid of that config, it can currently navigate itself to that
-       config, even though this is meant to only allow embedders to navigate fenced frames to
-       configs. This algorithm should be patched to be able to take in a FencedFrameConfig and use
-       that as the check to determine if this path is followed. See:
-       [issue #194](https://github.com/WICG/fenced-frame/issues/194)
+       Issue: The above condition is not as tight as it needs to be. For example, if a
+       <{fencedframe}> generates a {{FencedFrameConfig}} using a config-generating API, and then
+       correctly guesses the config's [=fencedframeconfig/urn|urn:uuid=], it can theoretically
+       navigate itself to that config by passing the guessed urn into the navigate algorithm as a
+       [=URL=], via something like the {{Window/location}} API. This is bad, because the purpose of
+       a {{FencedFrameConfig}} is to ensure that only an embedder can navigate a <{fencedframe}> to
+       the resource represented by the config, by using the config object directly. See <a
+       href=https://github.com/WICG/fenced-frame/issues/194>#194</a> for thoughts on fixing this.
 
       1. Let |config| be the result of [=fenced frame config mapping/finding a
          config=] in <var ignore>sourceDocument</var>'s [=node navigable=]'s [=navigable/traversable

--- a/spec.bs
+++ b/spec.bs
@@ -2879,7 +2879,10 @@ CORP violation report=] algorithm, as leaving it unfenced may cause a privacy le
       1. Set |config|'s [=fenced frame config/embedder shared storage context=] to
          |sharedStorageContext|.
 
-      1. Set <var ignore>sourceSnapshotParams</var>'s [=source snapshot params/target fenced frame
+      1. Assert: |sourceSnapshotParams|'s [=source snapshot params/target fenced frame config=] is
+         null.
+
+      1. Set |sourceSnapshotParams|'s [=source snapshot params/target fenced frame
          config=] to |config|.
 
       1. [=Assert=] |config|'s [=fenced frame config/mapped url=]'s [=mapped url/value=] is a
@@ -2889,7 +2892,7 @@ CORP violation report=] algorithm, as leaving it unfenced may cause a privacy le
 
       1. Run steps in |config|'s [=fenced frame config/on navigate callback=].
   
-    1. If |url| is a [=url=], |navigable| is a [=fenced navigable container/fenced navigable=], and
+    1. If |navigable| is a [=fenced navigable container/fenced navigable=], and
        <var ignore>sourceDocument</var>'s [=node navigable=] is not |navigable|:
 
       1. Let |config| be a new [=fenced frame config=] with the following [=struct/items=]:
@@ -2914,9 +2917,12 @@ CORP violation report=] algorithm, as leaving it unfenced may cause a privacy le
 
         : [=fenced frame config/effective enabled permissions=]
         :: null
+      
+      1. Assert: |sourceSnapshotParams|'s [=source snapshot params/target fenced frame config=] is
+         null.
 
-      1. Set <var ignore>sourceSnapshotParams</var>'s [=source snapshot params/target fenced frame
-         config=] to |config|.
+      1. Set |sourceSnapshotParams|'s [=source snapshot params/target fenced frame config=] to
+         |config|.
 
   <wpt>
     /fenced-frame/frame-navigation.https.html

--- a/spec.bs
+++ b/spec.bs
@@ -465,18 +465,19 @@ The <dfn attribute for=HTMLFencedFrameElement>config</dfn> IDL attribute getter 
        Note: This holds because when the element has been removed from the DOM, its removal steps
        immediately destroy the [=fenced navigable container/fenced navigable=].
 
-  1. Let |navigationUrn| be the given {{FencedFrameConfig}}'s [=fencedframeconfig/urn=].
+  1. Let |navigation url or urn| be the given {{FencedFrameConfig}}'s [=fencedframeconfig/url=] if
+     the given {{FencedFrameConfig}}'s [=fencedframeconfig/url=] is not null, and the given
+     {{FencedFrameConfig}}'s [=fencedframeconfig/urn=] otherwise.
 
-  1. If |navigationUrn| is not a valid [=urn uuid=] (i.e., won't pass the ABNF in Section 3 of
-     [=urn uuid=]), then return.
+  1. If |navigation url or urn| is failure, then return.
 
   1. Let |shared storage context| be the given {{FencedFrameConfig}}'s [=fencedframeconfig/
      sharedStorageContext=].
 
-  1. [=Navigate=] |element|'s [=fenced navigable container/fenced navigable=] to |navigationUrn|
-     using |element|'s [=Node/node document=], with [=historyHandling=] set to "<a for="history
-     handling behavior">`replace`</a>", [=referrerPolicy=] set to <a>"`no-referrer`"</a>, and
-     |shared storage context|.
+  1. [=Navigate=] |element|'s [=fenced navigable container/fenced navigable=] to
+     |navigation url or urn| using |element|'s [=Node/node document=], with [=historyHandling=] set
+     to "<a for="history handling behavior">`replace`</a>", [=referrerPolicy=] set to
+     <a>"`no-referrer`"</a>, and |shared storage context|.
 
      Note: See [[#navigation-changes]] for the <{fencedframe}>-specific changes to the ordinary
      navigation flow.
@@ -573,25 +574,6 @@ follows:
   1. [=Assert=]: |urn| does not [=map/exist=] in |pendingMapping|.
 
   1. [=map/Set=] |pendingMapping|[|urn|] to |config|.
-  
-  1. Return |urn|.
-</div>
-
-<div algorithm>
-  To <dfn for="fenced frame config mapping" export>store a finalized config</dfn> in a [=fenced
-  frame config mapping=] |mapping| given a [=fenced frame config=] |config|, run these steps:
-
-  1. Let |finalizedMapping| be |mapping|'s [=fenced frame config mapping/pending config mapping=].
-
-  1. If the [=map/size=] of |finalizedMapping| + the [=map/size=] of |mapping|'s [=fenced frame
-     config mapping/pending config mapping=] ≥ |mapping|'s [=fenced frame config mapping/maximum
-     number of configs=], return failure.
-
-  1. Let |urn| be a randomly generated [=urn uuid=].
-
-  1. [=Assert=]: |urn| does not [=map/exist=] in |finalizedMapping|.
-
-  1. [=map/Set=] |finalizedMapping|[|urn|] to |config|.
   
   1. Return |urn|.
 </div>
@@ -1365,6 +1347,7 @@ maps to an internal [=fenced frame config=] [=struct=].
 
 Each {{FencedFrameConfig}} has:
 
+ * A <dfn for=fencedframeconfig>url</dfn>, a [=URL=], failure, or null, initially null
  * A <dfn for=fencedframeconfig>urn</dfn>, a [=urn uuid=]
  * A <dfn for=fencedframeconfig>sharedStorageContext</dfn>, a [=string=]
  * A <dfn for=fencedframeconfig>containerWidth</dfn>, a {{FencedFrameConfigSize}} or null
@@ -1372,48 +1355,15 @@ Each {{FencedFrameConfig}} has:
  * A <dfn for=fencedframeconfig>contentWidth</dfn>, a {{FencedFrameConfigSize}} or null
  * A <dfn for=fencedframeconfig>contentHeight</dfn>, a {{FencedFrameConfigSize}} or null
 
+Note: A config's [=fencedframeconfig/url=] is only null if a [=fencedframeconfig/urn=] is supplied.
+
 <div algorithm>
   The <dfn constructor for=FencedFrameConfig>FencedFrameConfig(|url|)</dfn> constructor method steps
   are:
   
   1. Let |config| be a [=new=] {{FencedFrameConfig}} object.
 
-  1. Let |parsedUrl| be the result of running the [=URL parser=] on |url|.
-
-  1. If |parsedUrl| is not failure:
-
-     1. Let |global| be [=this=]'s [=relevant global object=].
-
-     1. Let |mapping| be |global|'s [=Window/navigable=]'s
-        [=navigable/traversable navigable=]'s [=traversable navigable/fenced frame config mapping=].
-
-     1. Let |configStruct| be a new [=fenced frame config=] with the following [=struct/items=]:
-
-        : [=fenced frame config/mapped url=]
-        :: a [=struct=] with the following [=struct/items=]:
-        
-           : [=mapped url/value=]
-           :: |parsedUrl|
-
-           : [=mapped url/visibility=]
-           :: [=visibility/transparent=]
-
-        : [=fenced frame config/effective sandbox flags=]
-        :: a [=struct=] with the following [=struct/items=]:
-        
-           : [=effective sandbox flags/value=]
-           :: The [=fencedframetype/default fenced frame effective sandboxing flags=].
-
-           : [=effective sandbox flags/visibility=]
-           :: [=visibility/opaque=]
-
-        : [=fenced frame config/effective enabled permissions=]
-        :: null
-
-     1. Let |urn| be the result of running [=fenced frame config mapping/store a finalized config=]
-        given |mapping| and |configStruct|.
-
-     1. Set |config|'s [=fencedframeconfig/urn=] to |urn|.
+  1. Set |config|'s [=fencedframeconfig/url=] to the result of running the [=URL parser=] on |url|.
 
   1. Return |config|.
 </div>
@@ -1448,6 +1398,8 @@ Each {{FencedFrameConfig}} has:
   |value|, |serialized|, and |forStorage| are:
 
   1. If |forStorage| is true, then throw a {{DataCloneError}} {{DOMException}}.
+
+  1. Set |serialized|.\[[Url]] to |value|'s [=fencedframeconfig/url=].
   
   1. Set |serialized|.\[[Urn]] to |value|'s [=fencedframeconfig/urn=].
 
@@ -1472,6 +1424,8 @@ Each {{FencedFrameConfig}} has:
 <div algorithm="FencedFrameConfig deserializer">
   Their [=deserialization steps=], given |serialized|, |value|, and <var ignore> targetRealm</var>
   are:
+  
+  1. Initialize |value|'s [=fencedframeconfig/url=] to |serialized|.\[[Url]].
   
   1. Initialize |value|'s [=fencedframeconfig/urn=] to |serialized|.\[[Urn]].
 
@@ -2878,6 +2832,35 @@ CORP violation report=] algorithm, as leaving it unfenced may cause a privacy le
       1. Set |url| to |config|'s [=fenced frame config/mapped url=]'s [=mapped url/value=].
 
       1. Run steps in |config|'s [=fenced frame config/on navigate callback=].
+  
+    1. If |url| is a [=url=], |navigable| is a [=fenced navigable container/fenced navigable=], and
+       <var ignore>sourceDocument</var>'s [=node navigable=] is not |navigable|:
+
+      1. Let |config| be a new [=fenced frame config=] with the following [=struct/items=]:
+
+        : [=fenced frame config/mapped url=]
+        :: a [=struct=] with the following [=struct/items=]:
+
+           : [=mapped url/value=]
+           :: |url|
+
+           : [=mapped url/visibility=]
+           :: [=visibility/transparent=]
+
+        : [=fenced frame config/effective sandbox flags=]
+        :: a [=struct=] with the following [=struct/items=]:
+
+           : [=effective sandbox flags/value=]
+           :: The [=fencedframetype/default fenced frame effective sandboxing flags=].
+
+           : [=effective sandbox flags/visibility=]
+           :: [=visibility/opaque=]
+
+        : [=fenced frame config/effective enabled permissions=]
+        :: null
+
+      1. Set <var ignore>sourceSnapshotParams</var>'s [=source snapshot params/target fenced frame
+         config=] to |config|.
 
   <wpt>
     /fenced-frame/frame-navigation.https.html

--- a/spec.bs
+++ b/spec.bs
@@ -465,19 +465,18 @@ The <dfn attribute for=HTMLFencedFrameElement>config</dfn> IDL attribute getter 
        Note: This holds because when the element has been removed from the DOM, its removal steps
        immediately destroy the [=fenced navigable container/fenced navigable=].
 
-  1. Let |navigation url or urn| be the given {{FencedFrameConfig}}'s [=fencedframeconfig/url=] if
-     the given {{FencedFrameConfig}}'s [=fencedframeconfig/url=] is not null, and the given
-     {{FencedFrameConfig}}'s [=fencedframeconfig/urn=] otherwise.
+  1. Let |navigationUrn| be the given {{FencedFrameConfig}}'s [=fencedframeconfig/urn=].
 
-  1. If |navigation url or urn| is failure, then return.
+  1. If |navigationUrn| is not a valid [=urn uuid=] (i.e., won't pass the ABNF in Section 3 of
+     [=urn uuid=]), then return.
 
   1. Let |shared storage context| be the given {{FencedFrameConfig}}'s [=fencedframeconfig/
      sharedStorageContext=].
 
-  1. [=Navigate=] |element|'s [=fenced navigable container/fenced navigable=] to
-     |navigation url or urn| using |element|'s [=Node/node document=], with [=historyHandling=] set
-     to "<a for="history handling behavior">`replace`</a>", [=referrerPolicy=] set to
-     <a>"`no-referrer`"</a>, and |shared storage context|.
+  1. [=Navigate=] |element|'s [=fenced navigable container/fenced navigable=] to |navigationUrn|
+     using |element|'s [=Node/node document=], with [=historyHandling=] set to "<a for="history
+     handling behavior">`replace`</a>", [=referrerPolicy=] set to <a>"`no-referrer`"</a>, and
+     |shared storage context|.
 
      Note: See [[#navigation-changes]] for the <{fencedframe}>-specific changes to the ordinary
      navigation flow.
@@ -574,6 +573,25 @@ follows:
   1. [=Assert=]: |urn| does not [=map/exist=] in |pendingMapping|.
 
   1. [=map/Set=] |pendingMapping|[|urn|] to |config|.
+  
+  1. Return |urn|.
+</div>
+
+<div algorithm>
+  To <dfn for="fenced frame config mapping" export>store a finalized config</dfn> in a [=fenced
+  frame config mapping=] |mapping| given a [=fenced frame config=] |config|, run these steps:
+
+  1. Let |finalizedMapping| be |mapping|'s [=fenced frame config mapping/pending config mapping=].
+
+  1. If the [=map/size=] of |finalizedMapping| + the [=map/size=] of |mapping|'s [=fenced frame
+     config mapping/pending config mapping=] ≥ |mapping|'s [=fenced frame config mapping/maximum
+     number of configs=], return failure.
+
+  1. Let |urn| be a randomly generated [=urn uuid=].
+
+  1. [=Assert=]: |urn| does not [=map/exist=] in |finalizedMapping|.
+
+  1. [=map/Set=] |finalizedMapping|[|urn|] to |config|.
   
   1. Return |urn|.
 </div>
@@ -717,6 +735,17 @@ following [=struct/items=]:
 
 An <dfn export for=fencedframetype>exhaustive set of sandbox flags</dfn> is a [=sandboxing flag
 set=].
+
+The <dfn export for=fencedframetype>default fenced frame effective sandboxing flags</dfn> are a
+[=sandboxing flag set=] with the following flags:
+
+* The [=sandboxed downloads browsing context flag=]
+* The [=sandboxed modals flag=]
+* The [=sandboxed navigation browsing context flag=]
+* The [=sandboxed orientation lock browsing context flag=]
+* The [=sandboxed pointer lock browsing context flag=]
+* The [=sandboxed presentation browsing context flag=]
+* The [=sandboxed top-level navigation without user activation browsing context flag=]
 
 A <dfn export for=fencedframetype>pending event</dfn> is a [=struct=] with the following
 [=struct/items=]:
@@ -1336,7 +1365,6 @@ maps to an internal [=fenced frame config=] [=struct=].
 
 Each {{FencedFrameConfig}} has:
 
- * A <dfn for=fencedframeconfig>url</dfn>, a [=URL=], failure, or null, initially null
  * A <dfn for=fencedframeconfig>urn</dfn>, a [=urn uuid=]
  * A <dfn for=fencedframeconfig>sharedStorageContext</dfn>, a [=string=]
  * A <dfn for=fencedframeconfig>containerWidth</dfn>, a {{FencedFrameConfigSize}} or null
@@ -1344,15 +1372,48 @@ Each {{FencedFrameConfig}} has:
  * A <dfn for=fencedframeconfig>contentWidth</dfn>, a {{FencedFrameConfigSize}} or null
  * A <dfn for=fencedframeconfig>contentHeight</dfn>, a {{FencedFrameConfigSize}} or null
 
-Note: A config's [=fencedframeconfig/url=] is only null if a [=fencedframeconfig/urn=] is supplied.
-
 <div algorithm>
   The <dfn constructor for=FencedFrameConfig>FencedFrameConfig(|url|)</dfn> constructor method steps
   are:
   
   1. Let |config| be a [=new=] {{FencedFrameConfig}} object.
 
-  1. Set |config|'s [=fencedframeconfig/url=] to the result of running the [=URL parser=] on |url|.
+  1. Let |parsedUrl| be the result of running the [=URL parser=] on |url|.
+
+  1. If |parsedUrl| is not failure:
+
+     1. Let |global| be [=this=]'s [=relevant global object=].
+
+     1. Let |mapping| be |global|'s [=Window/navigable=]'s
+        [=navigable/traversable navigable=]'s [=traversable navigable/fenced frame config mapping=].
+
+     1. Let |configStruct| be a new [=fenced frame config=] with the following [=struct/items=]:
+
+        : [=fenced frame config/mapped url=]
+        :: a [=struct=] with the following [=struct/items=]:
+        
+           : [=mapped url/value=]
+           :: |parsedUrl|
+
+           : [=mapped url/visibility=]
+           :: [=visibility/transparent=]
+
+        : [=fenced frame config/effective sandbox flags=]
+        :: a [=struct=] with the following [=struct/items=]:
+        
+           : [=effective sandbox flags/value=]
+           :: The [=fencedframetype/default fenced frame effective sandboxing flags=].
+
+           : [=effective sandbox flags/visibility=]
+           :: [=visibility/opaque=]
+
+        : [=fenced frame config/effective enabled permissions=]
+        :: null
+
+     1. Let |urn| be the result of running [=fenced frame config mapping/store a finalized config=]
+        given |mapping| and |configStruct|.
+
+     1. Set |config|'s [=fencedframeconfig/urn=] to |urn|.
 
   1. Return |config|.
 </div>
@@ -1388,8 +1449,6 @@ Note: A config's [=fencedframeconfig/url=] is only null if a [=fencedframeconfig
 
   1. If |forStorage| is true, then throw a {{DataCloneError}} {{DOMException}}.
   
-  1. Set |serialized|.\[[Url]] to |value|'s [=fencedframeconfig/url=].
-
   1. Set |serialized|.\[[Urn]] to |value|'s [=fencedframeconfig/urn=].
 
   1. Set |serialized|.\[[SharedStorageContext]] to |value|'s [=fencedframeconfig/
@@ -1413,8 +1472,6 @@ Note: A config's [=fencedframeconfig/url=] is only null if a [=fencedframeconfig
 <div algorithm="FencedFrameConfig deserializer">
   Their [=deserialization steps=], given |serialized|, |value|, and <var ignore> targetRealm</var>
   are:
-
-  1. Initialize |value|'s [=fencedframeconfig/url=] to |serialized|.\[[Url]].
   
   1. Initialize |value|'s [=fencedframeconfig/urn=] to |serialized|.\[[Urn]].
 

--- a/spec.bs
+++ b/spec.bs
@@ -2436,6 +2436,45 @@ in the [[#nested-traversables-intro]].
   1. Return |navigables|.
 </div>
 
+<div algorithm="inclusive-ancestor-navigables-patch">
+  Modify the [=Document/inclusive ancestor navigables=] algorithm to take a new optional
+  [=boolean=] argument <var><dfn lt="inclusive-an-unfenced">unfenced</dfn></var> that defaults to
+  false.
+
+  Further rewrite step 1 of this algorithm to:
+
+  1. Let <var ignore>navigables</var> be <var ignore>document</var>'s [=Document/ancestor
+     navigables=] with [=an-unfenced|unfenced=] set to
+     <var>[=inclusive-an-unfenced|unfenced=]</var>.
+</div>
+
+<div algorithm="ancestor-navigables-patch">
+  Modify the [=Document/ancestor navigables=] algorithm to take a new optional [=boolean=]
+  argument <dfn lt="an-unfenced">unfenced</dfn> that defaults to false, and rewrite the algorithm
+  like so:
+
+  1. Let |navigable| be |document|'s [=node navigable=]'s [=navigable/parent=].
+  
+  1. If |navigable| is null and [=an-unfenced|unfenced=] is true, set |navigable| to |document|'s
+     [=node navigable=]'s [=navigable/traversable navigable=]'s [=traversable navigable/unfenced
+     parent=].
+
+  1. Let |ancestors| be an empty list.
+
+  1. While |navigable| is not null:
+
+     1. [=list/Prepend=] |navigable| to |ancestors|.
+
+     1. Set |navigable| to |navigable|'s [=navigable/parent=].
+
+     1. If |navigable| is null and [=an-unfenced|unfenced=] is true, set |navigable| to
+        |navigable|'s [=navigable/traversable navigable=]'s [=traversable navigable/unfenced
+        parent=].
+
+  1. Return |ancestors|.
+
+</div>
+
 <h3 id=focusing-changes>Modifications to the focusing algorithms</h3>
 
 The [[HTML]] standard defines how to handle focusing elements and {{Window}}s, both by user gesture
@@ -2863,8 +2902,10 @@ CORP violation report=] algorithm, as leaving it unfenced may cause a privacy le
   Insert these steps immediately after step 20, the step that goes [=in parallel=], so that what
   follows are the first steps that run [=in parallel=] in the patched algorithm:
 
-    1. If |url| is a [=urn uuid=] and |navigable| is a [=fenced navigable container/fenced
-       navigable=]:
+    1. If |url| is a [=urn uuid=], |navigable| is a [=fenced navigable container/fenced navigable=],
+       and <var ignore>sourceDocument</var>'s [=node navigable=] is in |navigable|'s
+       [=navigable/active document=]'s [=Document/ancestor navigables=] with [=an-unfenced|
+       unfenced=] set to true:
 
       1. Let |config| be the result of [=fenced frame config mapping/finding a
          config=] in <var ignore>sourceDocument</var>'s [=node navigable=]'s [=navigable/traversable
@@ -2879,8 +2920,8 @@ CORP violation report=] algorithm, as leaving it unfenced may cause a privacy le
       1. Set |config|'s [=fenced frame config/embedder shared storage context=] to
          |sharedStorageContext|.
 
-      1. Assert: |sourceSnapshotParams|'s [=source snapshot params/target fenced frame config=] is
-         null.
+      1. [=Assert=]: |sourceSnapshotParams|'s [=source snapshot params/target fenced frame config=]
+         is null.
 
       1. Set |sourceSnapshotParams|'s [=source snapshot params/target fenced frame
          config=] to |config|.
@@ -2892,9 +2933,9 @@ CORP violation report=] algorithm, as leaving it unfenced may cause a privacy le
 
       1. Run steps in |config|'s [=fenced frame config/on navigate callback=].
   
-    1. If |navigable| is a [=fenced navigable container/fenced navigable=] and
-       <var ignore>sourceDocument</var>'s [=node navigable=] is in |navigable|'s
-       [=navigable/active document=]'s [=Document/ancestor navigables=]:
+    1. If |navigable| is a [=fenced navigable container/fenced navigable=] and <var
+       ignore>sourceDocument</var>'s [=node navigable=] is in |navigable|'s [=navigable/active
+       document=]'s [=Document/ancestor navigables=] with [=an-unfenced|unfenced=] set to true:
 
       1. Let |config| be a new [=fenced frame config=] with the following [=struct/items=]:
 
@@ -2919,8 +2960,8 @@ CORP violation report=] algorithm, as leaving it unfenced may cause a privacy le
         : [=fenced frame config/effective enabled permissions=]
         :: null
       
-      1. Assert: |sourceSnapshotParams|'s [=source snapshot params/target fenced frame config=] is
-         null.
+      1. [=Assert=]: |sourceSnapshotParams|'s [=source snapshot params/target fenced frame config=]
+         is null.
 
       1. Set |sourceSnapshotParams|'s [=source snapshot params/target fenced frame config=] to
          |config|.

--- a/spec.bs
+++ b/spec.bs
@@ -2902,10 +2902,15 @@ CORP violation report=] algorithm, as leaving it unfenced may cause a privacy le
   Insert these steps immediately after step 20, the step that goes [=in parallel=], so that what
   follows are the first steps that run [=in parallel=] in the patched algorithm:
 
-    1. If |url| is a [=urn uuid=], |navigable| is a [=fenced navigable container/fenced navigable=],
-       and <var ignore>sourceDocument</var>'s [=node navigable=] is in |navigable|'s
-       [=navigable/active document=]'s [=Document/ancestor navigables=] with [=an-unfenced|
-       unfenced=] set to true:
+    1. If |url| is a [=urn uuid=] and |navigable| is a [=fenced navigable container/fenced
+       navigable=]:
+
+       Issue: If a fenced frame generates a FencedFrameConfig using a config-generating API, and
+       then correctly guesses the urn:uuid of that config, it can currently navigate itself to that
+       config, even though this is meant to only allow embedders to navigate fenced frames to
+       configs. This algorithm should be patched to be able to take in a FencedFrameConfig and use
+       that as the check to determine if this path is followed. See:
+       [issue #194](https://github.com/WICG/fenced-frame/issues/194)
 
       1. Let |config| be the result of [=fenced frame config mapping/finding a
          config=] in <var ignore>sourceDocument</var>'s [=node navigable=]'s [=navigable/traversable

--- a/spec.bs
+++ b/spec.bs
@@ -2903,13 +2903,13 @@ CORP violation report=] algorithm, as leaving it unfenced may cause a privacy le
            : [=mapped url/visibility=]
            :: [=visibility/transparent=]
 
-        : [=fenced frame config/effective sandbox flags=]
+        : [=fenced frame config/effective sandboxing flags=]
         :: a [=struct=] with the following [=struct/items=]:
 
-           : [=effective sandbox flags/value=]
+           : [=effective sandboxing flags/value=]
            :: The [=fencedframetype/default fenced frame effective sandboxing flags=].
 
-           : [=effective sandbox flags/visibility=]
+           : [=effective sandboxing flags/visibility=]
            :: [=visibility/opaque=]
 
         : [=fenced frame config/effective enabled permissions=]


### PR DESCRIPTION
The existing spec results in a fenced frame navigating directly to the `url` stored in a `FencedFrameConfig` IDL object when navigating to a config built with the `FencedFrameConfig(url)` default constructor. This results in a `fenced frame config` and `fenced frame config instance` not being created for the fenced frame, cutting off the internal document from `window.fence`.

This PR fixes that in the following ways:

- Modifies the `FencedFrameConfig(url)` constructor to also create a `fenced frame config` and add it to the navigable's `fenced frame config mapping`.
- Unconditionally passes in the `FencedFrameConfig`'s `urn` when navigating the internal document, ensuring that the navigation will find the associated `fenced frame config`, and instantiate a `fenced frame config instance` as expected.
- Removes the `url` field from the `FencedFrameConfig` in favor of using the `mapped url` in the `fenced frame config`/`fenced frame config instance`.
- Adds a method to store a new `FencedFrameConfig` directly in the finalized mapping without first putting it in the pending mapping.

This PR also adds a `default fenced frame effective sandboxing flags` constant, which is needed when building the `fenced frame config` in the `FencedFrameConfing(url)` constructor.

See issue: https://github.com/WICG/fenced-frame/issues/178


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/WICG/fenced-frame/pull/183.html" title="Last updated on Oct 5, 2024, 7:50 PM UTC (3675ec4)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/fenced-frame/183/00676a5...3675ec4.html" title="Last updated on Oct 5, 2024, 7:50 PM UTC (3675ec4)">Diff</a>