### PR TITLE
Re-add fenced frame config internal container size.

### DIFF
--- a/spec.bs
+++ b/spec.bs
@@ -725,9 +725,9 @@ boundary, which can allow for colluding parties to join cross-site data and buil
 user. To prevent that, the ad auction API [=construct a pending fenced frame config|constructs=] a
 [=fenced frame config=] whose underlying [=fenced frame config/mapped url|URL=] is opaque to the
 embedding context. The [=fenced frame config=] is also constructed with restrictions on what the
-[=fenced frame config/content size=] of the frame must be and what the [=fenced frame config/
-effective enabled permissions|permissions policy=] of the frame must be, as those can be used as 
-fingerprinting vectors.
+[=fenced frame config/container size=] and [=fenced frame config/content size=] of the frame must 
+be and what the [=fenced frame config/effective enabled permissions|permissions policy=] of the 
+frame must be, as those can be used as fingerprinting vectors.
 
 Displaying a personalized payment button:
 
@@ -1127,6 +1127,9 @@ A <dfn export>fenced frame config</dfn> is a [=struct=] with the following [=str
     : <dfn for="mapped url">visibility</dfn>
     :: a [=fencedframeconfig/visibility=]
 
+  : <dfn>container size</dfn>
+  :: null, or a [=fencedframetype/size=]
+
   : <dfn>content size</dfn>
   :: null, or a [=struct=] with the following [=struct/items=]:
     : <dfn for="content size">value</dfn>
@@ -1223,6 +1226,9 @@ A <dfn export>fenced frame config instance</dfn> is a [=struct=] with the follow
   : <dfn>mapped url</dfn>
   :: a [=URL=]
 
+  : <dfn>container size</dfn>
+  :: null, or a [=fencedframetype/size=]
+
   : <dfn>content size</dfn>
   :: null, or a [=fencedframetype/size=]
 
@@ -1267,6 +1273,9 @@ A <dfn export>fenced frame config instance</dfn> is a [=struct=] with the follow
 
     : [=fenced frame config instance/mapped url=]
     :: |config|'s [=fenced frame config/mapped url=]'s [=mapped url/value=]
+
+    : [=fenced frame config instance/container size=]
+    :: |config|'s [=fenced frame config/container size=]
 
     : [=fenced frame config instance/content size=]
     :: |config|'s [=fenced frame config/content size=] if null, otherwise |config|'s [=fenced frame


### PR DESCRIPTION
Follow-up to https://github.com/WICG/fenced-frame/pull/182

Along with the unused IDL size attributes, I also removed the internal fenced frame config container size definition. I was mistaken about it being vestigial (I missed a reference to it in the implementation when I was originally deciding to remove it, so I didn't see it was actively used). 

The Protected Audience spec depended on the field, and I broke their build: https://github.com/WICG/turtledove/pull/1270#issuecomment-2332092944

This change re-adds the container size definition to un-break things.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/VergeA/fenced-frame/pull/187.html" title="Last updated on Sep 5, 2024, 5:43 PM UTC (38e8eb1)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/fenced-frame/187/a8ec772...VergeA:38e8eb1.html" title="Last updated on Sep 5, 2024, 5:43 PM UTC (38e8eb1)">Diff</a>