### PR TITLE
Export `fenced navigable`

### DIFF
--- a/spec.bs
+++ b/spec.bs
@@ -2203,9 +2203,9 @@ Similar to [=navigable containers=] and their respective [=navigable container/c
 other elements (so far, only the <{fencedframe}> element) present a more isolated [=navigable=] to
 the user. These elements are called <dfn>fenced navigable containers</dfn>.
 
-A [=fenced navigable container=] has a <dfn for="fenced navigable container">fenced navigable</dfn>,
-which is either a [=traversable navigable=] with a non-null [=traversable navigable/unfenced
-parent=], or null. It is initially null.
+A [=fenced navigable container=] has a <dfn export for="fenced navigable container">fenced
+navigable</dfn>, which is either a [=traversable navigable=] with a non-null [=traversable
+navigable/unfenced parent=], or null. It is initially null.
 
 <wpt>
   /fenced-frame/window-frameElement.https.html


### PR DESCRIPTION
https://github.com/WICG/PEPC/ would like to reference this term, so now that it has official consumers, I think exporting it seems reasonable.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/WICG/fenced-frame/pull/190.html" title="Last updated on Sep 12, 2024, 2:10 PM UTC (33119c6)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/fenced-frame/190/c10d8f6...33119c6.html" title="Last updated on Sep 12, 2024, 2:10 PM UTC (33119c6)">Diff</a>