### PR TITLE
Add spec for _unfencedTop navigation target.

### DIFF
--- a/spec.bs
+++ b/spec.bs
@@ -3315,11 +3315,12 @@ left over to be leaked to the next {{Document}}.
 <h4 id=unfenced-top-navigation-target>The "<code>_unfencedTop</code>" navigation target</h4>
 
 Fenced frames use an additional reserved navigation target "<code>_unfencedTop</code>" to navigate.
-This section patches the relevant portions of the [[HTML]] spec to add <code>_unfencedTop</code>.
+This section patches the relevant portions of the [[HTML]] spec to add support for this new
+reserved keyword.
 
 <div algorithm="unfenced-top-keyword">
-  Modify [=valid navigable target name or keyword=] to include a new keyword named <code>
-  _unfencedTop</code>.
+  Modify [=valid navigable target name or keyword=] to include a new keyword named
+  <code>_unfencedTop</code>.
 
   Modify the below paragraph to replace the following text:
 
@@ -3344,7 +3345,7 @@ This section patches the relevant portions of the [[HTML]] spec to add <code>_un
         <th rowspan=2>Keyword</th>
         <th rowspan=2>Ordinary effect</th>
         <th colspan=2>Effect in an <code>iframe</code> with...</th>
-        <th rowspan=2>Effect in a fenced frame</th>
+        <th rowspan=2>Effect in a <code>fencedframe</code>></th>
       </tr>
       <tr>          
         <th><code data-x="">sandbox=""</code></th>
@@ -3355,16 +3356,16 @@ This section patches the relevant portions of the [[HTML]] spec to add <code>_un
     <tbody>
       <tr>
         <td><code>_unfencedTop</code> if outermost top is current</td>
-        <td>current</td>
-        <td>current</td>
-        <td>current</td>
+        <td>new</td>
+        <td>maybe new</td>
+        <td>maybe new</td>
         <td>current</td>
       </tr>
       <tr>
         <td><code>_unfencedTop</code> if outermost top is not current</td>
-        <td>outermost top</td>
-        <td>none</td>
-        <td>outermost top</td>
+        <td>new</td>
+        <td>maybe new</td>
+        <td>maybe new</td>
         <td>outermost top</td>
       </tr>
     </tbody>
@@ -3375,7 +3376,7 @@ This section patches the relevant portions of the [[HTML]] spec to add <code>_un
   Add an extra step to [=the rules for choosing a navigable=] between the current steps 6 and 7, 
   that reads:
 
-  6.5. Otherwise, if name is an ASCII case-insensitive match for "_unfencedTop" and
+  6.5. Otherwise, if name is an ASCII case-insensitive match for <code>"_unfencedTop"</code> and
   |currentNavigable|'s [=navigable/traversable navigable=] is a [=fenced navigable container/fenced
   navigable=], set <var ignore=''>chosen</var> to |currentNavigable|'s [=top-level traversable=].
 </div>

--- a/spec.bs
+++ b/spec.bs
@@ -3317,58 +3317,68 @@ left over to be leaked to the next {{Document}}.
 Fenced frames use an additional reserved navigation target "<code>_unfencedTop</code>" to navigate.
 This section patches the relevant portions of the [[HTML]] spec to add <code>_unfencedTop</code>.
 
-Extend [=valid navigable target name or keyword=] to include a new keyword named <code>_unfencedTop
-</code>.
+<div algorithm="unfenced-top-keyword">
+  Modify [=valid navigable target name or keyword=] to include a new keyword named <code>
+  _unfencedTop</code>.
 
-In the following paragraph, change "top" to refer to the [=navigable/traversable navigable=] of the
-[=navigable=] that the link or script is in. Add an additional clause to the same sentence that
-reads: "outermost top" is the [=top-level traversable=] of the [=navigable=] that the link or
-script is in.
+  Modify the below paragraph to replace the following text:
 
-Note: This change is necessary because this spec adds a distinction between [=navigable/traversable
-navigable=] and [=top-level traversable=], which were previously functionally equivalent.
+    * "top" means the [=top-level traversable=] of the [=navigable=] that the link or script is in,
 
-In the table below, add a column named "Effect in a fenced frame". The value for all rows in
-this column is the same as "ordinary effect". Then, add two rows which read:
+  with: 
 
-<table>
-  <thead>
-    <tr>
-      <th rowspan=2>Keyword</th>
-      <th rowspan=2>Ordinary effect</th>
-      <th colspan=2>Effect in an <code>iframe</code> with...</th>
-      <th rowspan=2>Effect in a fenced frame</th>
-    </tr>
-    <tr>          
-      <th><code data-x="">sandbox=""</code></th>
-      <th><code data-x="">sandbox="allow-top-navigation"</code></th>
-    </tr>
-  </thead>
+    * "top" means the [=navigable/traversable navigable=] of the [=navigable=] that the link or
+      script is in, "outermost top" means the [=top-level traversable=] of the [=navigable=] that
+      the link or script is in, 
 
-  <tbody>
-    <tr>
-      <td><code>_unfencedTop</code> if outermost top is current</td>
-      <td>current</td>
-      <td>current</td>
-      <td>current</td>
-      <td>current</td>
-    </tr>
-    <tr>
-      <td><code>_unfencedTop</code> if outermost top is not current</td>
-      <td>outermost top</td>
-      <td>none</td>
-      <td>outermost top</td>
-      <td>outermost top</td>
-    </tr>
-  </tbody>
-</table>
+  Note: This change is necessary because this spec adds a distinction between
+  [=navigable/traversable navigable=] and [=top-level traversable=], which were previously
+  functionally equivalent.
 
-Add an extra step to [=the rules for choosing a navigable=] between the current steps 6 and 7, that
-reads:
+  In the table below, add a column named "Effect in a fenced frame". The value for all existing
+  rows in this column is the same as "ordinary effect". Then, add two rows which read:
 
-6.5. Otherwise, if name is an ASCII case-insensitive match for "_unfencedTop" and 
-|currentNavigable|'s [=navigable/traversable navigable=] is a [=fenced navigable container/fenced
-navigable=], set <var ignore=''>chosen</var> to |currentNavigable|'s [=top-level traversable=].
+  <table>
+    <thead>
+      <tr>
+        <th rowspan=2>Keyword</th>
+        <th rowspan=2>Ordinary effect</th>
+        <th colspan=2>Effect in an <code>iframe</code> with...</th>
+        <th rowspan=2>Effect in a fenced frame</th>
+      </tr>
+      <tr>          
+        <th><code data-x="">sandbox=""</code></th>
+        <th><code data-x="">sandbox="allow-top-navigation"</code></th>
+      </tr>
+    </thead>
+
+    <tbody>
+      <tr>
+        <td><code>_unfencedTop</code> if outermost top is current</td>
+        <td>current</td>
+        <td>current</td>
+        <td>current</td>
+        <td>current</td>
+      </tr>
+      <tr>
+        <td><code>_unfencedTop</code> if outermost top is not current</td>
+        <td>outermost top</td>
+        <td>none</td>
+        <td>outermost top</td>
+        <td>outermost top</td>
+      </tr>
+    </tbody>
+  </table>
+</div>
+
+<div algorithm="unfenced-top-rules">
+  Add an extra step to [=the rules for choosing a navigable=] between the current steps 6 and 7, 
+  that reads:
+
+  6.5. Otherwise, if name is an ASCII case-insensitive match for "_unfencedTop" and
+  |currentNavigable|'s [=navigable/traversable navigable=] is a [=fenced navigable container/fenced
+  navigable=], set <var ignore=''>chosen</var> to |currentNavigable|'s [=top-level traversable=].
+</div>
 
 <h3 id=page-visibility>Page visibility</h3>
 

--- a/spec.bs
+++ b/spec.bs
@@ -3312,13 +3312,13 @@ left over to be leaked to the next {{Document}}.
      mind, and could evolve in ways that give this specification unwanted side-effects.
 </div>
 
-<h4 id=unfenced-top-navigation-target>The "<code>_unfencedTop</code>" Navigation Target</h4>
+<h4 id=unfenced-top-navigation-target>The "<code>_unfencedTop</code>" navigation target</h4>
 
 Fenced frames use an additional reserved navigation target "<code>_unfencedTop</code>" to navigate.
 This section patches the relevant portions of the [[HTML]] spec to add <code>_unfencedTop</code>.
 
-Extend [=valid navigable target name or keyword=] to include <code>_unfencedTop</code> as one of
-the explicitly-listed possible matches.
+Extend [=valid navigable target name or keyword=] to include a new keyword named <code>_unfencedTop
+</code>.
 
 In the following paragraph, change "top" to refer to the [=navigable/traversable navigable=] of the
 [=navigable=] that the link or script is in. Add an additional clause to the same sentence that

--- a/spec.bs
+++ b/spec.bs
@@ -97,6 +97,9 @@ spec: html; urlPrefix: https://html.spec.whatwg.org/multipage/
       text: iframe sandboxing flag set; url: iframe-sandboxing-flag-set
       for: cross-origin opener policy enforcement result
         text: needs a browsing context group switch; url: coop-enforcement-bcg-switch
+    urlPrefix: document-sequences.html
+      text: valid navigable target name or keyword; url: valid-navigable-target-name-or-keyword
+      text: the rules for choosing a navigable; url: the-rules-for-choosing-a-navigable
     urlPrefix: dom.html
       text: categories; url: concept-element-categories
       text: contexts in which this element can be used; url: concept-element-contexts
@@ -3308,6 +3311,65 @@ left over to be leaked to the next {{Document}}.
      instead of piggybacking off of the COOP mechanism which was designed without fenced frames in
      mind, and could evolve in ways that give this specification unwanted side-effects.
 </div>
+
+<h4 id=unfenced-top-navigation-target>The "<code>_unfencedTop</code>" Navigation Target</h4>
+
+Fenced frames use an additional reserved navigation target "<code>_unfencedTop</code>" to navigate.
+This section patches the relevant portions of the [[HTML]] spec to add <code>_unfencedTop</code>.
+
+Extend [=valid navigable target name or keyword=] to include <code>_unfencedTop</code> as one of
+the explicitly-listed possible matches.
+
+In the following paragraph, change "top" to refer to the [=navigable/traversable navigable=] of the
+[=navigable=] that the link or script is in. Add an additional clause to the same sentence that
+reads: "outermost top" is the [=top-level traversable=] of the [=navigable=] that the link or
+script is in.
+
+Note: This change is necessary because this spec adds a distinction between [=navigable/traversable
+navigable=] and [=top-level traversable=], which were previously functionally equivalent.
+
+In the table below, add a column named "Effect in a fenced frame". The value for all rows in
+this column is the same as "ordinary effect". Then, add two rows which read:
+
+<table>
+  <thead>
+    <tr>
+      <th rowspan=2>Keyword</th>
+      <th rowspan=2>Ordinary effect</th>
+      <th colspan=2>Effect in an <code>iframe</code> with...</th>
+      <th rowspan=2>Effect in a fenced frame</th>
+    </tr>
+    <tr>          
+      <th><code data-x="">sandbox=""</code></th>
+      <th><code data-x="">sandbox="allow-top-navigation"</code></th>
+    <tr>
+   
+  </thead>
+
+  <tbody>
+    <tr>
+      <td><code>_unfencedTop</code> if outermost top is current</td>
+      <td>current</td>
+      <td>current</td>
+      <td>current</td>
+      <td>current</td>
+    </tr>
+    <tr>
+      <td><code>_unfencedTop</code> if outermost top is not current</td>
+      <td>outermost top</td>
+      <td>none</td>
+      <td>outermost top</td>
+      <td>outermost top</td>
+    </tr>
+  </tbody>
+</table>
+
+Add an extra step to [=the rules for choosing a navigable=] between the current steps 6 and 7, that
+reads:
+
+6.5. Otherwise, if name is an ASCII case-insensitive match for "_unfencedTop" and 
+|currentNavigable|'s [=navigable/traversable navigable=] is a [=fenced navigable container/fenced
+navigable=], set <var ignore=''>chosen</var> to |currentNavigable|'s [=top-level traversable=].
 
 <h3 id=page-visibility>Page visibility</h3>
 

--- a/spec.bs
+++ b/spec.bs
@@ -3342,8 +3342,7 @@ this column is the same as "ordinary effect". Then, add two rows which read:
     <tr>          
       <th><code data-x="">sandbox=""</code></th>
       <th><code data-x="">sandbox="allow-top-navigation"</code></th>
-    <tr>
-   
+    </tr>
   </thead>
 
   <tbody>

--- a/spec.bs
+++ b/spec.bs
@@ -3320,7 +3320,7 @@ reserved keyword.
 
 <div algorithm="unfenced-top-keyword">
   Modify [=valid navigable target name or keyword=] to include a new keyword named
-  <code>_unfencedTop</code>.
+  "<code>_unfencedTop</code>".
 
   Modify the below paragraph to replace the following text:
 


### PR DESCRIPTION
This is a rewrite of #174, converting the rough outline for the _unfencedTop navigation target spec into a formal patch.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/VergeA/fenced-frame/pull/200.html" title="Last updated on Nov 21, 2024, 3:22 PM UTC (c44f744)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/fenced-frame/200/a22434f...VergeA:c44f744.html" title="Last updated on Nov 21, 2024, 3:22 PM UTC (c44f744)">Diff</a>