### PR TITLE
Add spec for APIs gated on network revocation.

### DIFF
--- a/spec.bs
+++ b/spec.bs
@@ -2196,7 +2196,7 @@ table](https://fetch.spec.whatwg.org/#destination-table) to illustrate that <{fe
  * CSP directive of <code>fenced-frame-src</code>
  * Features as HTML's <code>&lt;fencedframe&gt;</code>
 
-<h3 id=methods-gated-on-network-revocation>Methods gated on network revocation</h3>
+<h3 id=gating-methods-on-network-revocation>Gating methods on network revocation</h3>
 
 *This first introductory paragraph is non-normative.*
 

--- a/spec.bs
+++ b/spec.bs
@@ -762,11 +762,11 @@ can freely flow in and out without risk of the credit card information being joi
 data. Because of that, the fenced frame can be constructed directly from the web platform using the
 {{FencedFrameConfig}} constructor without compromising privacy. The button at this point has no
 personalized data in it since it can't access the credit card data yet. The {{Document}} can only
-read that credit card data once it turns off all network access, preventing the data from flowing
-out of the fenced frame and preventing it from being joined with cross-site data to build a user
-profile. Once it does that, the button will then display the last 4 digits of the user's credit card
-number, as it is saved in the browser, inside the first-party storage partition for the ecommerce
-platform's origin.
+read that credit card data once it turns off all network access via
+{{Fence/disableUntrustedNetwork()}}, preventing the data from flowing out of the fenced frame and
+preventing it from being joined with cross-site data to build a user profile. Once it does that,
+the button will then display the last 4 digits of the user's credit card number, as it is saved in
+the browser, inside the first-party storage partition for the ecommerce platform's origin.
 
 <h4 id=fenced-frame-config-struct>The [=fenced frame config=] [=struct=]</h4>
 
@@ -2195,6 +2195,34 @@ table](https://fetch.spec.whatwg.org/#destination-table) to illustrate that <{fe
  * [=request/initiator=] ""
  * CSP directive of <code>fenced-frame-src</code>
  * Features as HTML's <code>&lt;fencedframe&gt;</code>
+
+<h3 id=methods-gated-on-network-revocation>Methods Gated on Network Revocation</h3>
+
+*This first introductory paragraph is non-normative.*
+
+After a fenced frame has fully disabled untrusted network access, meaning the {{Promise}} returned
+by {{Fence/disableUntrustedNetwork()}} has [=resolved=], certain powerful interface methods will
+become available to script which executes inside of the fenced frame. These methods are defined in
+other specifications, which will use the below algorithm to determine if invocation can occur
+successfully. Currently, the only method which is gated behind revocation of untrusted network
+access is {{SharedStorage/get()}} when invoked outside of a {{SharedStorageWorklet}}. This method
+is defined in the [[Shared-Storage]] draft specification.
+
+<div algorithm>
+  To <dfn export>determine if a navigable has fully revoked network</dfn> given a [=navigable=] 
+  |navigable|:
+  
+  1. If |navigable|'s [=navigable/traversable navigable=] is not a [=fenced navigable
+     container/fenced navigable=], return false.
+
+  1. Let |config| be |navigable|'s [=navigable/active browsing context=]'s [=browsing
+     context/fenced frame config instance=].
+
+  1. If |config|'s [=fenced frame config instance/untrusted network status=] is not [=untrusted
+     network status/disabled for this tree and fenced subtrees=], return false.
+
+  1. Return true.
+</div>
 
 <h3 id=automatic-reporting>Automatic Reporting</h3>
 

--- a/spec.bs
+++ b/spec.bs
@@ -2196,7 +2196,7 @@ table](https://fetch.spec.whatwg.org/#destination-table) to illustrate that <{fe
  * CSP directive of <code>fenced-frame-src</code>
  * Features as HTML's <code>&lt;fencedframe&gt;</code>
 
-<h3 id=methods-gated-on-network-revocation>Methods Gated on Network Revocation</h3>
+<h3 id=methods-gated-on-network-revocation>Methods gated on network revocation</h3>
 
 *This first introductory paragraph is non-normative.*
 

--- a/spec.bs
+++ b/spec.bs
@@ -2204,9 +2204,9 @@ After a fenced frame has fully disabled untrusted network access, meaning the {{
 by {{Fence/disableUntrustedNetwork()}} has [=resolved=], certain powerful interface methods will
 become available to script which executes inside of the fenced frame. These methods are defined in
 other specifications, which will use the below algorithm to determine if invocation can occur
-successfully. Currently, the only method which is gated behind revocation of untrusted network
-access is {{SharedStorage/get()}} when invoked outside of a {{SharedStorageWorklet}}. This method
-is defined in the [[Shared-Storage]] draft specification.
+successfully. One example of a method which is gated behind revocation of untrusted network access
+is {{SharedStorage/get()}} when invoked outside of a {{SharedStorageWorklet}}. This method is
+defined in the [[Shared-Storage]] draft specification.
 
 <div algorithm>
   To <dfn export>determine if a navigable has fully revoked network</dfn> given a [=navigable=] 


### PR DESCRIPTION
After untrusted network access has been disabled in a fenced frame via disableUntrustedNetwork(), script running in the frame will gain access to new powerful APIs. This patch provides an algorithm that other specs can use when implementing methods that should only succeed in a fenced frame with network access revoked.

Currently, the only method that will rely on this algorithm is SharedStorage.get(), which is implemented in the Shared Storage draft spec. I'm planning to update that spec separately after this PR merges.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/VergeA/fenced-frame/pull/204.html" title="Last updated on Jan 14, 2025, 7:16 PM UTC (9fa9fbc)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/fenced-frame/204/ffd3d63...VergeA:9fa9fbc.html" title="Last updated on Jan 14, 2025, 7:16 PM UTC (9fa9fbc)">Diff</a>