### PR TITLE
[Spec] Network revocation patches for WebSocket and WebTransport APIs

### DIFF
--- a/spec.bs
+++ b/spec.bs
@@ -269,6 +269,18 @@ spec: attribution-reporting; urlPrefix: https://wicg.github.io/attribution-repor
 spec: turtledove; urlPrefix: https://wicg.github.io/turtledove/
   type: dfn
     text: construct a pending fenced frame config; url: construct-a-pending-fenced-frame-config
+spec: RFC6455; urlPrefix: https://datatracker.ietf.org/doc/html/rfc6455
+  type: dfn
+    text: fail the WebSocket connection; url: #section-7.1.7
+spec: WebSocket; urlPrefix: https://websockets.spec.whatwg.org/
+  type: dfn
+    text: establish a WebSocket connection; url: #concept-websocket-establish
+spec: WebTransport; urlPrefix: https://w3c.github.io/webtransport
+  type: dfn
+    for: WebTransport
+      text: cleanup; url: #webtransport-cleanup
+      text: queue a network task; url: #webtransport-queue-a-network-task
+    text: initialize WebTransport over HTTP; url: #initialize-webtransport-over-http
 </pre>
 
 <style>
@@ -2123,6 +2135,16 @@ Issue: This will require a RFC to add a test-only function to the WPT web driver
   1. [=set/Append=] |nonce| to the user agent's [=network revocation nonce set=].
 
   1. [=fetch group/terminated|Terminate=] |settings|'s [=fetch/fetch group=].
+
+  1. [=list/For each=] {{WebSocket}} object |webSocket| whose [=relevant settings object=] is
+     |settings|, run [=fail the WebSocket connection=] given |webSocket|.
+
+  1. [=list/For each=] {{WebTransport}} object |webTransport| whose [=relevant settings object=] is
+     |settings|, [=WebTransport/cleanup=] |webTransport| with a newly [=exception/create|created=]
+     {{WebTransportError}} whose {{WebTransportErrorOptions/source}} is `"session"`.
+
+     Note: Not passing in a {{WebTransportCloseInfo}} ensures that the {{WebTransport}} object is
+     set to the `"failed"` state rather than the `"closed"` state.
 </div>
 
 <div algorithm>
@@ -2161,7 +2183,41 @@ The network revocation mechanism requires the following monkeypatches to the [[F
   (<a href="https://github.com/WICG/fenced-frame/issues/191">WICG/fenced-frame#191</a>)
 </div>
 
-The network revocation mechanism requires the following monkeypatches to the [[HTML]] Standard.
+<h3 id=disable-websocket>WebSocket monkeypatches for network revocation</h3>
+
+The network revocation mechanism requires the following monkeypatch to the [[WebSockets]]
+Standard.
+
+<div algorithm=establish-websocket-patch>
+  Modify the [=establish a WebSocket connection=] algorithm. Add a new step after step 10 that
+  reads:
+
+  11. If the result of running [=determine if a navigable has revoked network for itself=] given
+      <var ignore>client</var>'s [=environment settings object/global object=]'s
+      [=Window/navigable=] is true, [=fail the WebSocket connection=].
+</div>
+
+<h3 id=disable-webtransport>WebTransport monkeypatches for network revocation</h3>
+
+The network revocation mechanism requires the following monkeypatch to the [[WebTransport]]
+Standard.
+
+<div algorithm=initialize-webtransport-patch>
+  Modify the [=initialize WebTransport over HTTP=] algorithm. Rewrite step 5 (keeping all substeps
+  unchanged) to read:
+
+  5. If any of the following conditions are true:
+     
+     - Running [=should request be blocked by Content Security Policy?=] with |request| returns
+       **"Blocked"**;
+     - Running [=should request be blocked due to a bad port=] with |request| returns **"blocked"**;
+     - Running [=determine if a navigable has revoked network for itself=] given <var
+       ignore>client</var>'s [=environment settings object/global object=]'s [=Window/navigable=]
+       returns true;
+     
+     then abort the remaining steps and [=WebTransport/queue a network task=] with
+     <var ignore>transport</var> to run these steps:
+</div>
 
 <h3 id=new-request-destination>New [=request=] [=request/destination=]</h3>
 
@@ -2195,6 +2251,24 @@ table](https://fetch.spec.whatwg.org/#destination-table) to illustrate that <{fe
  * [=request/initiator=] ""
  * CSP directive of <code>fenced-frame-src</code>
  * Features as HTML's <code>&lt;fencedframe&gt;</code>
+
+<h3 id=methods-gated-on-network-revocation>Methods gated on network revocation</h3>
+
+<div algorithm>
+  To <dfn>determine if a navigable has revoked network for itself</dfn> given a [=navigable=] 
+  |navigable|:
+
+  1. If |navigable|'s [=navigable/traversable navigable=] is not a [=fenced navigable
+     container/fenced navigable=], return false.
+
+  1. Let |config| be |navigable|'s [=navigable/active browsing context=]'s [=browsing
+     context/fenced frame config instance=].
+
+  1. If |config|'s [=fenced frame config instance/untrusted network status=] is not [=untrusted
+     network status/enabled=], return true.
+
+  1. Return false.
+</div>
 
 <h3 id=automatic-reporting>Automatic Reporting</h3>
 

--- a/spec.bs
+++ b/spec.bs
@@ -2167,11 +2167,12 @@ Issue: This will require a RFC to add a test-only function to the WPT web driver
 
 *This introductory section is non-normative.*
 
-The network revocation mechanism requires various patches to various standards. These standards
-involve making some sort of network request in a way that is currently unaware of the network status
-of the context that resulted in the request ultimately being sent out. To patch that, we add checks
-in places that require it. For more information, there are non-external WPTs that test these various
-APIs that [can be found
+The network revocation mechanism in this section requires patching standards that make network
+requests. Before our patches, these standards make network requests (such as initiate WebSocket
+connections) while unaware of the network revocation status of the context that ultimately initiated
+the request. Our patches add checks to the algorithm in those standards to consider the network
+revocation status of the initiating context before the request is made. For more information, there
+are non-external WPTs that test these various APIs that [can be found
 here](https://source.chromium.org/chromium/chromium/src/+/main:third_party/blink/web_tests/wpt_internal/fenced_frame/).
 These are currently not external simply because the network revocation feature has not launched yet.
 Once launched, they will be published to the WPT repo.

--- a/spec.bs
+++ b/spec.bs
@@ -2269,6 +2269,10 @@ In the intermediate state where {{Fence/disableUntrustedNetwork()}} has been cal
 requests over the network. The second algorithm below is used to determine whether those features
 are allowed.
 
+We make the distinction between "fully revoked" and "revoked for self"
+because nested fenced frame trees might still have network access, and these restrictions will not
+apply to them until they have invoked {{Fence/disableUntrustedNetwork()}} as well. 
+
 <div algorithm>
   To <dfn export>determine if a navigable has fully revoked network</dfn> given a [=navigable=] 
   |navigable|:

--- a/spec.bs
+++ b/spec.bs
@@ -2264,10 +2264,10 @@ table](https://fetch.spec.whatwg.org/#destination-table) to illustrate that <{fe
   1. Let |config| be |navigable|'s [=navigable/active browsing context=]'s [=browsing
      context/fenced frame config instance=].
 
-  1. If |config|'s [=fenced frame config instance/untrusted network status=] is not [=untrusted
-     network status/enabled=], return true.
+  1. If |config|'s [=fenced frame config instance/untrusted network status=] is [=untrusted network
+     status/enabled=], return false.
 
-  1. Return false.
+  1. Return true.
 </div>
 
 <h3 id=automatic-reporting>Automatic Reporting</h3>

--- a/spec.bs
+++ b/spec.bs
@@ -2163,7 +2163,18 @@ Issue: This will require a RFC to add a test-only function to the WPT web driver
   1. Return <b>allowed</b>.
 </div>
 
-<h3 id=disable-fetch>Fetch monkeypatches for network revocation</h3>
+<h3 id=disable-monkeypatches>Monkeypatches for network revocation</h3>
+
+*This introductory section is non-normative.*
+
+The network revocation mechanism requires various patches to various standards. These standards
+involve making some sort of network request in a way that is currently unaware of the network status
+of the context that resulted in the request ultimately being sent out. To patch that, we add checks
+in places that require it. For more information, there are non-external WPTs that test these various
+APIs that [can be found
+here](https://source.chromium.org/chromium/chromium/src/+/main:third_party/blink/web_tests/wpt_internal/fenced_frame/).
+These are currently not external simply because the network revocation feature has not launched yet.
+Once launched, they will be published to the WPT repo.
 
 The network revocation mechanism requires the following monkeypatches to the [[FETCH]] Standard.
 
@@ -2185,8 +2196,6 @@ The network revocation mechanism requires the following monkeypatches to the [[F
   (<a href="https://github.com/WICG/fenced-frame/issues/191">WICG/fenced-frame#191</a>)
 </div>
 
-<h3 id=disable-websocket>WebSocket monkeypatches for network revocation</h3>
-
 The network revocation mechanism requires the following monkeypatch to the [[WebSockets]]
 Standard.
 
@@ -2198,8 +2207,6 @@ Standard.
       <var ignore>client</var>'s [=environment settings object/global object=]'s
       [=Window/navigable=] is true, [=fail the WebSocket connection=].
 </div>
-
-<h3 id=disable-webtransport>WebTransport monkeypatches for network revocation</h3>
 
 The network revocation mechanism requires the following monkeypatch to the [[WebTransport]]
 Standard.

--- a/spec.bs
+++ b/spec.bs
@@ -2015,6 +2015,16 @@ Several APIs specific to fenced frames are defined on the {{Fence}} interface.
 
   1. Let |settings| be [=this=]'s [=relevant settings object=].
 
+  1. [=list/For each=] {{WebSocket}} object |webSocket| whose [=relevant global object=] is
+     |global|, run [=fail the WebSocket connection=] given |webSocket|.
+
+  1. [=list/For each=] {{WebTransport}} object |webTransport| whose [=relevant global object=] is
+     |global|, [=WebTransport/cleanup=] |webTransport| with a newly [=exception/create|created=]
+     {{WebTransportError}} whose {{WebTransportErrorOptions/source}} is `"session"`.
+
+     Note: Not passing in a {{WebTransportCloseInfo}} ensures that the {{WebTransport}} object is
+     set to the `"failed"` state rather than the `"closed"` state.
+
   1. Run the following steps [=in parallel=]:
 
      1. Let |fencedFrameNonce| be |instance|'s [=fenced frame config instance/partition nonce=].
@@ -2132,19 +2142,11 @@ Issue: This will require a RFC to add a test-only function to the WPT web driver
   instance/partition nonce=] |nonce| given a [=relevant settings object=] |settings|, run these
   steps:
 
+  1. [=Assert=]: this is running [=in parallel=].
+
   1. [=set/Append=] |nonce| to the user agent's [=network revocation nonce set=].
 
   1. [=fetch group/terminated|Terminate=] |settings|'s [=fetch/fetch group=].
-
-  1. [=list/For each=] {{WebSocket}} object |webSocket| whose [=relevant settings object=] is
-     |settings|, run [=fail the WebSocket connection=] given |webSocket|.
-
-  1. [=list/For each=] {{WebTransport}} object |webTransport| whose [=relevant settings object=] is
-     |settings|, [=WebTransport/cleanup=] |webTransport| with a newly [=exception/create|created=]
-     {{WebTransportError}} whose {{WebTransportErrorOptions/source}} is `"session"`.
-
-     Note: Not passing in a {{WebTransportCloseInfo}} ensures that the {{WebTransport}} object is
-     set to the `"failed"` state rather than the `"closed"` state.
 </div>
 
 <div algorithm>


### PR DESCRIPTION
This ensures that the following things happen for both `WebTransport` and `WebSocket` objects:

- All open connections associated with a context are closed when untrusted network access is revoked.
- New connections cannot be created after network access is revoked.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/WICG/fenced-frame/pull/206.html" title="Last updated on Feb 19, 2025, 2:27 AM UTC (997d803)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/fenced-frame/206/82a9f09...997d803.html" title="Last updated on Feb 19, 2025, 2:27 AM UTC (997d803)">Diff</a>