### PR TITLE
Check that document is fully active for window.fence methods

### DIFF
--- a/spec.bs
+++ b/spec.bs
@@ -1759,8 +1759,10 @@ Several APIs specific to fenced frames are defined on the {{Fence}} interface.
 <div algorithm>
   The <dfn method for=Fence>reportEvent(|event|)</dfn> method steps are:
 
-  1. If [=this=]'s {{Document}} is not [=Document/fully active=], then [=exception/throw=] a
-     {{SecurityError}} {{DOMException}}.
+  1. Let |document| be [=this=]'s [=relevant global object=]'s [=associated Document=].
+
+  1. If |document| is not [=Document/fully active=], then [=exception/throw=] a {{SecurityError}}
+     {{DOMException}}.
 
   1. Let |instance| be [=this=]'s [=relevant global object=]'s [=Window/browsing context=]'s
      [=browsing context/fenced frame config instance=].
@@ -1770,8 +1772,6 @@ Several APIs specific to fenced frames are defined on the {{Fence}} interface.
   1. If |instance|'s [=fenced frame config instance/is ad component=] is true, then return.
 
   1. If |instance|'s [=fenced frame config instance/fenced frame reporter=] is null, then return.
-
-  1. Let |document| be [=this=]'s [=relevant global object=]'s [=associated Document=].
 
   1. Let |request initiator| be [=this=]'s [=relevant settings object=]'s [=environment settings
      object/origin=].
@@ -1871,8 +1871,8 @@ Several APIs specific to fenced frames are defined on the {{Fence}} interface.
   The <dfn method for=Fence>setReportEventDataForAutomaticBeacons(|event|)</dfn>
   method steps are:
 
-  1. If [=this=]'s {{Document}} is not [=Document/fully active=], then [=exception/throw=] a
-     {{SecurityError}} {{DOMException}}.
+  1. If [=this=]'s [=relevant global object=]'s [=associated Document=] is not [=Document/fully
+     active=], then [=exception/throw=] a {{SecurityError}} {{DOMException}}.
 
   1. If |event| does not have a {{FenceEvent/destination}} or |event| does not have a
      {{FenceEvent/eventType}}:
@@ -1955,8 +1955,8 @@ Several APIs specific to fenced frames are defined on the {{Fence}} interface.
 <div algorithm>
   The <dfn method for=Fence>notifyEvent(|event|)</dfn> method steps are:
 
-  1. If [=this=]'s {{Document}} is not [=Document/fully active=], then [=exception/throw=] a
-     {{SecurityError}} {{DOMException}}.
+  1. If [=this=]'s [=relevant global object=]'s [=associated Document=] is not [=Document/fully
+     active=], then [=exception/throw=] a {{SecurityError}} {{DOMException}}.
 
   1. Let |navigable| be [=this=]'s [=relevant global object=]'s [=Window/navigable=].
   
@@ -2000,8 +2000,8 @@ Several APIs specific to fenced frames are defined on the {{Fence}} interface.
 
   1. Let |p| be [=a new promise=].
 
-  1. If [=this=]'s {{Document}} is not [=Document/fully active=], then [=exception/throw=] a
-     {{SecurityError}} {{DOMException}}.
+  1. If [=this=]'s [=relevant global object=]'s [=associated Document=] is not [=Document/fully
+     active=], then [=exception/throw=] a {{SecurityError}} {{DOMException}}.
 
   1. Let |instance| be [=this=]'s [=relevant global object=]'s [=Window/browsing context=]'s
      [=browsing context/fenced frame config instance=].

--- a/spec.bs
+++ b/spec.bs
@@ -1527,7 +1527,7 @@ Note: A config's [=fencedframeconfig/url=] is only null if a [=fencedframeconfig
   {{FencedFrameConfig}} objects are [=serializable objects=]. Their [=serialization steps=], given
   |value|, |serialized|, and |forStorage| are:
 
-  1. If |forStorage| is true, then throw a {{DataCloneError}} {{DOMException}}.
+  1. If |forStorage| is true, then [=exception/throw=] a {{DataCloneError}} {{DOMException}}.
   
   1. Set |serialized|.\[[Url]] to |value|'s [=fencedframeconfig/url=].
 
@@ -1680,11 +1680,11 @@ partial interface Navigator {
   1. Let |instance| be [=this=]'s [=relevant global object=]'s [=Window/browsing context=]'s
      [=browsing context/fenced frame config instance=].
 
-  1. If |instance| is null, then throw a {{DOMException}}.
+  1. If |instance| is null, then [=exception/throw=] a {{DOMException}}.
 
   1. If [=this=]'s [=relevant settings object=]'s [=environment settings object/origin=] and
     |instance|'s [=fenced frame config instance/mapped url=]'s [=url/origin=] are not [=same
-    origin=], then then throw a {{DOMException}}.
+    origin=], then then [=exception/throw=] a {{DOMException}}.
 
   1. Let |maxAdComponents| be 40.
 
@@ -1758,6 +1758,9 @@ Several APIs specific to fenced frames are defined on the {{Fence}} interface.
 
 <div algorithm>
   The <dfn method for=Fence>reportEvent(|event|)</dfn> method steps are:
+
+  1. If [=this=]'s {{Document}} is not [=Document/fully active=], then [=exception/throw=] a
+     {{SecurityError}} {{DOMException}}.
 
   1. Let |instance| be [=this=]'s [=relevant global object=]'s [=Window/browsing context=]'s
      [=browsing context/fenced frame config instance=].
@@ -1867,6 +1870,10 @@ Several APIs specific to fenced frames are defined on the {{Fence}} interface.
 <div algorithm>
   The <dfn method for=Fence>setReportEventDataForAutomaticBeacons(|event|)</dfn>
   method steps are:
+
+  1. If [=this=]'s {{Document}} is not [=Document/fully active=], then [=exception/throw=] a
+     {{SecurityError}} {{DOMException}}.
+
   1. If |event| does not have a {{FenceEvent/destination}} or |event| does not have a
      {{FenceEvent/eventType}}:
      1. [=exception/Throw=] a {{TypeError}}.
@@ -1948,11 +1955,13 @@ Several APIs specific to fenced frames are defined on the {{Fence}} interface.
 <div algorithm>
   The <dfn method for=Fence>notifyEvent(|event|)</dfn> method steps are:
 
-  1. If [=this=]'s {{Document}} is not [=Document/fully active=], then return.
+  1. If [=this=]'s {{Document}} is not [=Document/fully active=], then [=exception/throw=] a
+     {{SecurityError}} {{DOMException}}.
 
   1. Let |navigable| be [=this=]'s [=relevant global object=]'s [=Window/navigable=].
   
-  1. If any of the following conditions are met, then throw a {{SecurityError}} {{DOMException}}:
+  1. If any of the following conditions are met, then [=exception/throw=] a {{SecurityError}}
+     {{DOMException}}:
 
       * |navigable| is not a [=fenced navigable container/fenced navigable=];
   
@@ -1991,11 +2000,13 @@ Several APIs specific to fenced frames are defined on the {{Fence}} interface.
 
   1. Let |p| be [=a new promise=].
 
-  1. Let |context| be [=this=]'s [=relevant global object=]'s [=Window/browsing context=].
+  1. If [=this=]'s {{Document}} is not [=Document/fully active=], then [=exception/throw=] a
+     {{SecurityError}} {{DOMException}}.
 
-  1. If |context| is null, then throw a {{SecurityError}} {{DOMException}}.
+  1. Let |instance| be [=this=]'s [=relevant global object=]'s [=Window/browsing context=]'s
+     [=browsing context/fenced frame config instance=].
 
-  1. Let |instance| be |context|'s [=browsing context/fenced frame config instance=].
+  1. If |instance| is null, then return.
 
   1. If the [=relevant settings object=]'s [=environment settings object/origin=] and
      |instance|'s [=fenced frame config instance/mapped url=]'s [=url/origin=] are not [=same

--- a/spec.bs
+++ b/spec.bs
@@ -1680,11 +1680,11 @@ partial interface Navigator {
   1. Let |instance| be [=this=]'s [=relevant global object=]'s [=Window/browsing context=]'s
      [=browsing context/fenced frame config instance=].
 
-  1. If |instance| is null, then [=exception/throw=] a {{DOMException}}.
+  1. If |instance| is null, then [=exception/throw=] an {{InvalidStateError}} {{DOMException}}.
 
   1. If [=this=]'s [=relevant settings object=]'s [=environment settings object/origin=] and
     |instance|'s [=fenced frame config instance/mapped url=]'s [=url/origin=] are not [=same
-    origin=], then then [=exception/throw=] a {{DOMException}}.
+    origin=], then then [=exception/throw=] an {{InvalidStateError}} {{DOMException}}.
 
   1. Let |maxAdComponents| be 40.
 


### PR DESCRIPTION
This PR makes the following changes

- Add fully active document checks in `window.fence` methods as they appear in the associated implementation.
- Move the `{{SecurityError}}` check in `disableUntrustedNetwork()` to the newly added active document check.
- Have all instances of `throw` link to the [throw definition](https://webidl.spec.whatwg.org/#dfn-throw).


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/WICG/fenced-frame/pull/209.html" title="Last updated on Feb 4, 2025, 7:15 PM UTC (13f22b3)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/fenced-frame/209/1c78202...13f22b3.html" title="Last updated on Feb 4, 2025, 7:15 PM UTC (13f22b3)">Diff</a>