### PR TITLE
Spec descendant frames' ongoing navigations block disableUntrustedNetwork promise from being resolved

### DIFF
--- a/spec.bs
+++ b/spec.bs
@@ -2069,12 +2069,10 @@ Several APIs specific to fenced frames are defined on the {{Fence}} interface.
      
         1. If |currentNavigable|' [=navigable/ongoing navigation=] is a [=navigation ID=]:
         
-            1. Let |ancestorNavigables| be |currentNavigable|'s [=navigable/active document=]'s 
-               [=Document/ancestor navigables=] with [=an-unfenced|unfenced=] set to false.
-               
-            1. If |ancestorNavigables| is [=list/is not empty=] and the last element of 
-               |ancestorNavigables| is a [=fenced navigable container/fenced navigable=], then 
-               [=set/append=] that element to |navigablesWithNetworkChildren|.
+            1. Let |ancestorFencedRoot| be |currentNavigable|'s [=navigable/traversable navigable=].
+
+            1. If |ancestorFencedRoot| is a [=fenced navigable container/fenced navigable=],
+               [=set/append=] |ancestorFencedRoot| to |navigablesWithNetworkChildren|.
         
         1. [=iteration/continue=].
 

--- a/spec.bs
+++ b/spec.bs
@@ -145,6 +145,7 @@ spec: html; urlPrefix: https://html.spec.whatwg.org/multipage/
       text: historyHandling; url: navigation-hh
       text: referrerPolicy; url: navigation-referrer-policy
       text: attempt to populate the history entry's document; url: attempt-to-populate-the-history-entry's-document
+      text: navigation ID; url: navigation-id
       text: navigation params; url: navigation-params
       text: snapshot source snapshot params; url: snapshotting-source-snapshot-params
       text: the navigation must be a replace; url: the-navigation-must-be-a-replace
@@ -2064,14 +2065,25 @@ Several APIs specific to fenced frames are defined on the {{Fence}} interface.
 
      1. Let |currentNavigable| be the result of [=stack/pop|popping=] from |navigables|.
 
-     1. If |currentNavigable| is not a [=fenced navigable container/fenced navigable=], then
-        [=iteration/continue=].
+     1. If |currentNavigable| is not a [=fenced navigable container/fenced navigable=]:
+     
+        1. If |currentNavigable|' [=navigable/ongoing navigation=] is a [=Navigation Id=]:
+        
+            1. Let |ancestorNavigables| be |currentNavigable|'s [=navigable/active document=]'s 
+               [=Document/ancestor navigables=] with [=an-unfenced|unfenced=] set to false.
+               
+            1. If |ancestorNavigables| is [=list/is not empty=] and the last element of 
+               |ancestorNavigables| is a [=fenced navigable container/fenced navigable=], then 
+               [=set/append=] that element to |navigablesWithNetworkChildren|.
+        
+        1. [=iteration/continue=].
 
      1. Let |config| be |currentNavigable|'s [=navigable/active browsing context=]'s [=browsing
         context/fenced frame config instance=].
 
      1. If |config|'s [=fenced frame config instance/untrusted network status=] is [=untrusted
-        network status/disabled for this tree and fenced subtrees=], then [=iteration/continue=].
+        network status/disabled for this tree and fenced subtrees=] and |currentNavigable|' 
+        [=navigable/ongoing navigation=] is not a [=Navigation Id=], then [=iteration/continue=].
 
      1. Let |networkCutoffReady| be true if |navigablesWithNetworkChildren| does not [=set/contain=]
         |currentNavigable| and |config|'s [=fenced frame config instance/untrusted network status=]
@@ -2099,7 +2111,9 @@ Several APIs specific to fenced frames are defined on the {{Fence}} interface.
 
         1. [=map/Clear=] |config|'s [=fenced frame config instance/on network disabled promises=].
 
-     1. Otherwise:
+     1. If |networkCutoffReady| is false or |currentNavigable|' [=navigable/ongoing navigation=] is 
+        a [=Navigation Id=]:
+        
         1. Let |ancestorFencedRoot| be |currentNavigable|'s [=traversable navigable/unfenced
            parent=]'s [=navigable/traversable navigable=].
 

--- a/spec.bs
+++ b/spec.bs
@@ -2067,7 +2067,7 @@ Several APIs specific to fenced frames are defined on the {{Fence}} interface.
 
      1. If |currentNavigable| is not a [=fenced navigable container/fenced navigable=]:
      
-        1. If |currentNavigable|' [=navigable/ongoing navigation=] is a [=Navigation Id=]:
+        1. If |currentNavigable|' [=navigable/ongoing navigation=] is a [=navigation ID=]:
         
             1. Let |ancestorNavigables| be |currentNavigable|'s [=navigable/active document=]'s 
                [=Document/ancestor navigables=] with [=an-unfenced|unfenced=] set to false.
@@ -2083,7 +2083,7 @@ Several APIs specific to fenced frames are defined on the {{Fence}} interface.
 
      1. If |config|'s [=fenced frame config instance/untrusted network status=] is [=untrusted
         network status/disabled for this tree and fenced subtrees=] and |currentNavigable|' 
-        [=navigable/ongoing navigation=] is not a [=Navigation Id=], then [=iteration/continue=].
+        [=navigable/ongoing navigation=] is not a [=navigation ID=], then [=iteration/continue=].
 
      1. Let |networkCutoffReady| be true if |navigablesWithNetworkChildren| does not [=set/contain=]
         |currentNavigable| and |config|'s [=fenced frame config instance/untrusted network status=]
@@ -2112,7 +2112,7 @@ Several APIs specific to fenced frames are defined on the {{Fence}} interface.
         1. [=map/Clear=] |config|'s [=fenced frame config instance/on network disabled promises=].
 
      1. If |networkCutoffReady| is false or |currentNavigable|' [=navigable/ongoing navigation=] is 
-        a [=Navigation Id=]:
+        a [=navigation ID=]:
         
         1. Let |ancestorFencedRoot| be |currentNavigable|'s [=traversable navigable/unfenced
            parent=]'s [=navigable/traversable navigable=].

--- a/spec.bs
+++ b/spec.bs
@@ -2141,7 +2141,7 @@ Several APIs specific to fenced frames are defined on the {{Fence}} interface.
            [=set/append=] |ancestorFencedRoot| to |navigablesWithNetworkChildren|.
            
   Note: The Chromium-internal web platform test is available at <a
-  href="https://source.chromium.org/chromium/chromium/src/+/main:third_party/blink/web_tests/wpt_internal/fenced_frame/disable-untrusted-network-ongoing-navigation.https.html">third_party/blink/web_tests/wpt_internal/fenced_frame/disable-untrusted-network-ongoing-navigation.https.html</a>.
+  href="https://source.chromium.org/chromium/chromium/src/+/main:third_party/blink/web_tests/wpt_internal/fenced_frame/disable-untrusted-network-ongoing-navigation.https.html">third_party/blink/web_tests/wpt_internal/fenced_frame/disable-untrusted-network-ongoing-navigation.https.html</a>. It will be merged upstreamed once <a href="https://github.com/WICG/fenced-frame/issues/192">WICG/fenced-frame#192</a> is resolveed.
   
 </div>
 

--- a/spec.bs
+++ b/spec.bs
@@ -2072,14 +2072,17 @@ Several APIs specific to fenced frames are defined on the {{Fence}} interface.
         
             1. Let |ancestorFencedRoot| be |currentNavigable|'s [=navigable/traversable navigable=].
 
-            1. If |ancestorFencedRoot| is a [=fenced navigable container/fenced navigable=], [=set/append=] |ancestorFencedRoot| to |navigablesWithNetworkChildren|.
+            1. If |ancestorFencedRoot| is a [=fenced navigable container/fenced navigable=],
+               [=set/append=] |ancestorFencedRoot| to |navigablesWithNetworkChildren|.
         
         1. [=iteration/continue=].
 
      1. Let |config| be |currentNavigable|'s [=navigable/active browsing context=]'s [=browsing
         context/fenced frame config instance=].
 
-     1. If |config|'s [=fenced frame config instance/untrusted network status=] is [=untrusted network status/disabled for this tree and fenced subtrees=] and |ongoingNavigation| is null, then [=iteration/continue=].
+     1. If |config|'s [=fenced frame config instance/untrusted network status=] is [=untrusted
+        network status/disabled for this tree and fenced subtrees=] and |ongoingNavigation| is null,
+        then [=iteration/continue=].
 
      1. Let |networkCutoffReady| be true if |navigablesWithNetworkChildren| does not [=set/contain=]
         |currentNavigable| and |config|'s [=fenced frame config instance/untrusted network status=]

--- a/spec.bs
+++ b/spec.bs
@@ -2141,7 +2141,9 @@ Several APIs specific to fenced frames are defined on the {{Fence}} interface.
            [=set/append=] |ancestorFencedRoot| to |navigablesWithNetworkChildren|.
            
   Note: The Chromium-internal web platform test is available at <a
-  href="https://source.chromium.org/chromium/chromium/src/+/main:third_party/blink/web_tests/wpt_internal/fenced_frame/disable-untrusted-network-ongoing-navigation.https.html">third_party/blink/web_tests/wpt_internal/fenced_frame/disable-untrusted-network-ongoing-navigation.https.html</a>. It will be merged upstreamed once <a href="https://github.com/WICG/fenced-frame/issues/192">WICG/fenced-frame#192</a> is resolveed.
+  href="https://source.chromium.org/chromium/chromium/src/+/main:third_party/blink/web_tests/wpt_internal/fenced_frame/disable-untrusted-network-ongoing-navigation.https.html">third_party/blink/web_tests/wpt_internal/fenced_frame/disable-untrusted-network-ongoing-navigation.https.html</a>.
+  It will be merged upstreamed once <a
+  href="https://github.com/WICG/fenced-frame/issues/192">WICG/fenced-frame#192</a> is resolveed.
   
 </div>
 

--- a/spec.bs
+++ b/spec.bs
@@ -2073,7 +2073,7 @@ Several APIs specific to fenced frames are defined on the {{Fence}} interface.
             1. Let |ancestorFencedRoot| be |currentNavigable|'s [=navigable/traversable navigable=].
 
             1. If |ancestorFencedRoot| is a [=fenced navigable container/fenced navigable=],
-               [=set/append=] |ancestorFencedRoot| to |navigablesWithNetworkChildren|.
+            [=set/append=] |ancestorFencedRoot| to |navigablesWithNetworkChildren|.
         
         1. [=iteration/continue=].
 
@@ -2081,8 +2081,8 @@ Several APIs specific to fenced frames are defined on the {{Fence}} interface.
         context/fenced frame config instance=].
 
      1. If |config|'s [=fenced frame config instance/untrusted network status=] is [=untrusted
-        network status/disabled for this tree and fenced subtrees=] and |ongoingNavigation| is null,
-        then [=iteration/continue=].
+     network status/disabled for this tree and fenced subtrees=] and |ongoingNavigation| is null,
+     then [=iteration/continue=].
 
      1. Let |networkCutoffReady| be true if |navigablesWithNetworkChildren| does not [=set/contain=]
         |currentNavigable| and |config|'s [=fenced frame config instance/untrusted network status=]

--- a/spec.bs
+++ b/spec.bs
@@ -2072,17 +2072,14 @@ Several APIs specific to fenced frames are defined on the {{Fence}} interface.
         
             1. Let |ancestorFencedRoot| be |currentNavigable|'s [=navigable/traversable navigable=].
 
-            1. If |ancestorFencedRoot| is a [=fenced navigable container/fenced navigable=],
-            [=set/append=] |ancestorFencedRoot| to |navigablesWithNetworkChildren|.
+            1. If |ancestorFencedRoot| is a [=fenced navigable container/fenced navigable=], [=set/append=] |ancestorFencedRoot| to |navigablesWithNetworkChildren|.
         
         1. [=iteration/continue=].
 
      1. Let |config| be |currentNavigable|'s [=navigable/active browsing context=]'s [=browsing
         context/fenced frame config instance=].
 
-     1. If |config|'s [=fenced frame config instance/untrusted network status=] is [=untrusted
-     network status/disabled for this tree and fenced subtrees=] and |ongoingNavigation| is null,
-     then [=iteration/continue=].
+     1. If |config|'s [=fenced frame config instance/untrusted network status=] is [=untrusted network status/disabled for this tree and fenced subtrees=] and |ongoingNavigation| is null, then [=iteration/continue=].
 
      1. Let |networkCutoffReady| be true if |navigablesWithNetworkChildren| does not [=set/contain=]
         |currentNavigable| and |config|'s [=fenced frame config instance/untrusted network status=]

--- a/spec.bs
+++ b/spec.bs
@@ -2064,10 +2064,12 @@ Several APIs specific to fenced frames are defined on the {{Fence}} interface.
   1. [=iteration/While=] |navigables| is not [=stack/empty=]:
 
      1. Let |currentNavigable| be the result of [=stack/pop|popping=] from |navigables|.
+     
+     1. Let |ongoingNavigation| be |currentNavigable|'s [=navigable/ongoing navigation=].
 
      1. If |currentNavigable| is not a [=fenced navigable container/fenced navigable=]:
      
-        1. If |currentNavigable|' [=navigable/ongoing navigation=] is a [=navigation ID=]:
+        1. If |ongoingNavigation| is a [=navigation ID=]:
         
             1. Let |ancestorFencedRoot| be |currentNavigable|'s [=navigable/traversable navigable=].
 
@@ -2080,8 +2082,8 @@ Several APIs specific to fenced frames are defined on the {{Fence}} interface.
         context/fenced frame config instance=].
 
      1. If |config|'s [=fenced frame config instance/untrusted network status=] is [=untrusted
-        network status/disabled for this tree and fenced subtrees=] and |currentNavigable|' 
-        [=navigable/ongoing navigation=] is not a [=navigation ID=], then [=iteration/continue=].
+        network status/disabled for this tree and fenced subtrees=] and |ongoingNavigation| is not a
+        [=navigation ID=], then [=iteration/continue=].
 
      1. Let |networkCutoffReady| be true if |navigablesWithNetworkChildren| does not [=set/contain=]
         |currentNavigable| and |config|'s [=fenced frame config instance/untrusted network status=]
@@ -2109,8 +2111,7 @@ Several APIs specific to fenced frames are defined on the {{Fence}} interface.
 
         1. [=map/Clear=] |config|'s [=fenced frame config instance/on network disabled promises=].
 
-     1. If |networkCutoffReady| is false or |currentNavigable|' [=navigable/ongoing navigation=] is 
-        a [=navigation ID=]:
+     1. If |networkCutoffReady| is false or |ongoingNavigation| is a [=navigation ID=]:
         
         1. Let |ancestorFencedRoot| be |currentNavigable|'s [=traversable navigable/unfenced
            parent=]'s [=navigable/traversable navigable=].

--- a/spec.bs
+++ b/spec.bs
@@ -2142,7 +2142,7 @@ Several APIs specific to fenced frames are defined on the {{Fence}} interface.
            
   Note: The Chromium-internal web platform test is available at <a
   href="https://source.chromium.org/chromium/chromium/src/+/main:third_party/blink/web_tests/wpt_internal/fenced_frame/disable-untrusted-network-ongoing-navigation.https.html">third_party/blink/web_tests/wpt_internal/fenced_frame/disable-untrusted-network-ongoing-navigation.https.html</a>.
-  It will be merged upstreamed once <a
+  It will be upstreamed and linked here once <a
   href="https://github.com/WICG/fenced-frame/issues/192">WICG/fenced-frame#192</a> is resolveed.
   
 </div>

--- a/spec.bs
+++ b/spec.bs
@@ -2140,7 +2140,7 @@ Several APIs specific to fenced frames are defined on the {{Fence}} interface.
         1. If |ancestorFencedRoot| is a [=fenced navigable container/fenced navigable=],
            [=set/append=] |ancestorFencedRoot| to |navigablesWithNetworkChildren|.
            
-  Note: The Chromium-internal web platform tests is available at <a href="https://source.chromium.org/chromium/chromium/src/+/main:third_party/blink/web_tests/wpt_internal/fenced_frame/disable-untrusted-network-ongoing-navigation.https.html">third_party/blink/web_tests/wpt_internal/fenced_frame/disable-untrusted-network-ongoing-navigation.https.html</a>. 
+  Note: The Chromium-internal web platform test is available at <a href="https://source.chromium.org/chromium/chromium/src/+/main:third_party/blink/web_tests/wpt_internal/fenced_frame/disable-untrusted-network-ongoing-navigation.https.html">third_party/blink/web_tests/wpt_internal/fenced_frame/disable-untrusted-network-ongoing-navigation.https.html</a>. 
 </div>
 
 <div algorithm=iframe-remove-patch>

--- a/spec.bs
+++ b/spec.bs
@@ -2140,7 +2140,9 @@ Several APIs specific to fenced frames are defined on the {{Fence}} interface.
         1. If |ancestorFencedRoot| is a [=fenced navigable container/fenced navigable=],
            [=set/append=] |ancestorFencedRoot| to |navigablesWithNetworkChildren|.
            
-  Note: The Chromium-internal web platform test is available at <a href="https://source.chromium.org/chromium/chromium/src/+/main:third_party/blink/web_tests/wpt_internal/fenced_frame/disable-untrusted-network-ongoing-navigation.https.html">third_party/blink/web_tests/wpt_internal/fenced_frame/disable-untrusted-network-ongoing-navigation.https.html</a>. 
+  Note: The Chromium-internal web platform test is available at <a
+  href="https://source.chromium.org/chromium/chromium/src/+/main:third_party/blink/web_tests/wpt_internal/fenced_frame/disable-untrusted-network-ongoing-navigation.https.html">third_party/blink/web_tests/wpt_internal/fenced_frame/disable-untrusted-network-ongoing-navigation.https.html</a>.
+  
 </div>
 
 <div algorithm=iframe-remove-patch>

--- a/spec.bs
+++ b/spec.bs
@@ -2139,6 +2139,8 @@ Several APIs specific to fenced frames are defined on the {{Fence}} interface.
 
         1. If |ancestorFencedRoot| is a [=fenced navigable container/fenced navigable=],
            [=set/append=] |ancestorFencedRoot| to |navigablesWithNetworkChildren|.
+           
+  Note: The Chromium-internal web platform tests is available at <a href="https://source.chromium.org/chromium/chromium/src/+/main:third_party/blink/web_tests/wpt_internal/fenced_frame/disable-untrusted-network-ongoing-navigation.https.html">third_party/blink/web_tests/wpt_internal/fenced_frame/disable-untrusted-network-ongoing-navigation.https.html</a>. 
 </div>
 
 <div algorithm=iframe-remove-patch>

--- a/spec.bs
+++ b/spec.bs
@@ -145,7 +145,6 @@ spec: html; urlPrefix: https://html.spec.whatwg.org/multipage/
       text: historyHandling; url: navigation-hh
       text: referrerPolicy; url: navigation-referrer-policy
       text: attempt to populate the history entry's document; url: attempt-to-populate-the-history-entry's-document
-      text: navigation ID; url: navigation-id
       text: navigation params; url: navigation-params
       text: snapshot source snapshot params; url: snapshotting-source-snapshot-params
       text: the navigation must be a replace; url: the-navigation-must-be-a-replace
@@ -2069,7 +2068,7 @@ Several APIs specific to fenced frames are defined on the {{Fence}} interface.
 
      1. If |currentNavigable| is not a [=fenced navigable container/fenced navigable=]:
      
-        1. If |ongoingNavigation| is a [=navigation ID=]:
+        1. If |ongoingNavigation| is not null:
         
             1. Let |ancestorFencedRoot| be |currentNavigable|'s [=navigable/traversable navigable=].
 
@@ -2082,8 +2081,8 @@ Several APIs specific to fenced frames are defined on the {{Fence}} interface.
         context/fenced frame config instance=].
 
      1. If |config|'s [=fenced frame config instance/untrusted network status=] is [=untrusted
-        network status/disabled for this tree and fenced subtrees=] and |ongoingNavigation| is not a
-        [=navigation ID=], then [=iteration/continue=].
+        network status/disabled for this tree and fenced subtrees=] and |ongoingNavigation| is null,
+        then [=iteration/continue=].
 
      1. Let |networkCutoffReady| be true if |navigablesWithNetworkChildren| does not [=set/contain=]
         |currentNavigable| and |config|'s [=fenced frame config instance/untrusted network status=]
@@ -2111,7 +2110,7 @@ Several APIs specific to fenced frames are defined on the {{Fence}} interface.
 
         1. [=map/Clear=] |config|'s [=fenced frame config instance/on network disabled promises=].
 
-     1. If |networkCutoffReady| is false or |ongoingNavigation| is a [=navigation ID=]:
+     1. If |networkCutoffReady| is false or |ongoingNavigation| is not null:
         
         1. Let |ancestorFencedRoot| be |currentNavigable|'s [=traversable navigable/unfenced
            parent=]'s [=navigable/traversable navigable=].


### PR DESCRIPTION
fix: #205

This PR only implements the change in algorithm "recalculate the untrusted network status of all fenced frame descendants".

The part that this algorithm should be called whenever a navigation commits will be done in a follow-up PR. I'm still investigating how to spec this. See previous [comment](https://github.com/WICG/fenced-frame/pull/176#discussion_r1881105124) on this.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/xiaochen-z/fenced-frame/pull/210.html" title="Last updated on Feb 25, 2025, 2:37 PM UTC (ced0b67)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/fenced-frame/210/fa4ec2c...xiaochen-z:ced0b67.html" title="Last updated on Feb 25, 2025, 2:37 PM UTC (ced0b67)">Diff</a>