### PR TITLE
Fix spec build failure due to visibilities ref

### DIFF
--- a/spec.bs
+++ b/spec.bs
@@ -746,11 +746,12 @@ being able to manipulate the environment in which the ad loads.
 We achieve this using the concept of a "[=fenced frame config=]". A [=fenced frame config=] is a
 collection of fields that can be loaded into <{fencedframe}> elements and that specifies the
 resulting environments. [=Fenced frame configs=] can only be created by specific web platform APIs,
-and not constructed or modified by script. Their fields also contain "[=fencedframeconfig/visibilities=]", which
-dictate whether the field should be "redacted" when inspected through the {{FencedFrameConfig}}
-interface. Config-generating APIs like the [[Protected-Audience]] and [[Shared-Storage]] APIs must
-specify values for all fields of their [=fenced frame configs=] in order to ensure that they have
-considered the privacy implications of each field, though they may choose to set the values to null.
+and not constructed or modified by script. Their fields also contain
+"[=fencedframeconfig/visibilities=]", which dictate whether the field should be "redacted" when
+inspected through the {{FencedFrameConfig}} interface. Config-generating APIs like the
+[[Protected-Audience]] and [[Shared-Storage]] APIs must specify values for all fields of their
+[=fenced frame configs=] in order to ensure that they have considered the privacy implications of
+each field, though they may choose to set the values to null.
 
 Each time a <{fencedframe}> navigates to a [=fenced frame config=], it is instantiated as a new
 [=fenced frame config instance=], which governs the particular [=browsing context group=] inside the

--- a/spec.bs
+++ b/spec.bs
@@ -746,7 +746,7 @@ being able to manipulate the environment in which the ad loads.
 We achieve this using the concept of a "[=fenced frame config=]". A [=fenced frame config=] is a
 collection of fields that can be loaded into <{fencedframe}> elements and that specifies the
 resulting environments. [=Fenced frame configs=] can only be created by specific web platform APIs,
-and not constructed or modified by script. Their fields also contain "[=visibilities=]", which
+and not constructed or modified by script. Their fields also contain "[=fencedframeconfig/visibilities=]", which
 dictate whether the field should be "redacted" when inspected through the {{FencedFrameConfig}}
 interface. Config-generating APIs like the [[Protected-Audience]] and [[Shared-Storage]] APIs must
 specify values for all fields of their [=fenced frame configs=] in order to ensure that they have

--- a/spec.bs
+++ b/spec.bs
@@ -640,12 +640,13 @@ Note: The purpose of pending configs is to enable config-generating APIs to reso
 asynchronously in a way that doesn't create timing side channels, i.e., the pending config is
 returned to the web platform in a constant amount of time, before any computation whose duration
 depends on cross-site data. Because the privacy of this depends on the web platform not being able
-to discern when a pending config is finalized, it is important that all [=fencedframeconfig/visibilities=] and values of
-transparent fields do not change from the pending config to the finalized config, given that they
-can be inspected through {{FencedFrameConfig}}'s getters. Therefore, a {{FencedFrameConfig}} that is
-created and exposed to the web platform is effectively immutable even if the [=fenced frame config=]
-represented by the [=fencedframe/config=]'s [=fencedframeconfig/urn=] is technically "pending", and
-will finish resolving completely later.
+to discern when a pending config is finalized, it is important that all
+[=fencedframeconfig/visibilities=] and values of transparent fields do not change from the pending
+config to the finalized config, given that they can be inspected through {{FencedFrameConfig}}'s
+getters. Therefore, a {{FencedFrameConfig}} that is created and exposed to the web platform is
+effectively immutable even if the [=fenced frame config=] represented by the
+[=fencedframe/config=]'s [=fencedframeconfig/urn=] is technically "pending", and will finish
+resolving completely later.
 
 Each [=fenced frame config mapping=] has a <dfn for="fenced frame config mapping">maximum number of
 configs</dfn>, which is implementation-defined. The [=fenced frame config mapping/maximum number of

--- a/spec.bs
+++ b/spec.bs
@@ -640,7 +640,7 @@ Note: The purpose of pending configs is to enable config-generating APIs to reso
 asynchronously in a way that doesn't create timing side channels, i.e., the pending config is
 returned to the web platform in a constant amount of time, before any computation whose duration
 depends on cross-site data. Because the privacy of this depends on the web platform not being able
-to discern when a pending config is finalized, it is important that all visibilities and values of
+to discern when a pending config is finalized, it is important that all [=fencedframeconfig/visibilities=] and values of
 transparent fields do not change from the pending config to the finalized config, given that they
 can be inspected through {{FencedFrameConfig}}'s getters. Therefore, a {{FencedFrameConfig}} that is
 created and exposed to the web platform is effectively immutable even if the [=fenced frame config=]


### PR DESCRIPTION
Fix spec build failure #211 

The current `[=visibilities=]` is referencing https://www.w3.org/TR/CSS22/visufx.html#propdef-visibility, which is incorrect. 

It should be `[=fencedframeconfig/visibilities=]` which references:
https://github.com/WICG/fenced-frame/blob/6fa197f163e3b0defbb925e95e8aefe83f804e7c/spec.bs#L793-L794

Also add the reference to the other "visibilities" in the spec.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/xiaochen-z/fenced-frame/pull/212.html" title="Last updated on Feb 24, 2025, 3:21 PM UTC (0d38af5)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/fenced-frame/212/6fa197f...xiaochen-z:0d38af5.html" title="Last updated on Feb 24, 2025, 3:21 PM UTC (0d38af5)">Diff</a>