### PR TITLE
Recalculate network status when navigation ends

### DIFF
--- a/spec.bs
+++ b/spec.bs
@@ -2149,8 +2149,9 @@ Several APIs specific to fenced frames are defined on the {{Fence}} interface.
 <div algorithm=set-ongoing-navigation-patch>
   Modify the [=set the ongoing navigation=] algorithm. Add a new step after step 2 that reads:
   
-  3. If <var ignore>newValue</var> is null, [=in parallel=], [=recalculate the untrusted network status of all fenced frame descendants=]
-     given the <var ignore>navigable</var>'s [=navigable/top-level traversable=].
+  3. If <var ignore>newValue</var> is null, [=in parallel=], [=recalculate the untrusted network
+     status of all fenced frame descendants=] given the <var ignore>navigable</var>'s
+     [=navigable/top-level traversable=].
 </div>
 
 A user agent has an associated <dfn>network revocation nonce set</dfn>, which is a [=set=] of

--- a/spec.bs
+++ b/spec.bs
@@ -148,6 +148,7 @@ spec: html; urlPrefix: https://html.spec.whatwg.org/multipage/
       text: navigation params; url: navigation-params
       text: snapshot source snapshot params; url: snapshotting-source-snapshot-params
       text: the navigation must be a replace; url: the-navigation-must-be-a-replace
+      text: set the ongoing navigation; url: set-the-ongoing-navigation
       for: navigation params
         text: response; url: navigation-params-response
         text: navigable; url: navigation-params-navigable
@@ -2143,6 +2144,13 @@ Several APIs specific to fenced frames are defined on the {{Fence}} interface.
 
   1. [=In parallel=], [=recalculate the untrusted network status of all fenced frame descendants=]
      given |topLevelTraversable|.
+</div>
+
+<div algorithm=set-ongoing-navigation-patch>
+  Modify the [=set the ongoing navigation=] algorithm. Add a new step after step 2 that reads:
+  
+  3. If <var ignore>newValue</var> is null, [=in parallel=], [=recalculate the untrusted network status of all fenced frame descendants=]
+     given the <var ignore>navigable</var>'s [=navigable/top-level traversable=].
 </div>
 
 A user agent has an associated <dfn>network revocation nonce set</dfn>, which is a [=set=] of


### PR DESCRIPTION
Fix #214.

After some investigations, it seems adding the recalculation step in `set the ongoing navigation` algorithm makes the most sense.

The only similar feature in the current standard is the navigation API, which has two [promises](https://html.spec.whatwg.org/#navigation-api-method-tracker-committed). Their resolution or rejection are done when certain navigation events are fired. See:
* [resolve the finished promise](https://html.spec.whatwg.org/#resolve-the-finished-promise)
* [reject the finished promise](https://html.spec.whatwg.org/#reject-the-finished-promise)

However, these promises are only relevant for navigations that are intercepted by the navigation API. When a cross-site navigation is not intercepted by the navigation API, no resolution or rejection steps are run on the promises because they will disappear together with the current document, as stated in the [explainer](https://github.com/WICG/navigation-api/blob/main/README.md#the-navigate-and-reload-methods) (See the last paragraph in the linked section):

> And if they are non-intercepted cross-document navigations, then the returned promises, along with the entire JavaScript global environment, will disappear as the current document gets unloaded.

So simply adding the recalculation steps to where navigation API resolves its promises does not work as the cross-document navigation cases are not handled.

In the implementation, the network status recalculation is done whenever a navigation ends. In other words, when a frame changes from having an ongoing navigation, to not having an ongoing navigation. So it appears [set the ongoing navigation](https://html.spec.whatwg.org/#set-the-ongoing-navigation) algorithm is the best place to add this step because it is the centralized place where the ongoing navigation state is changed.

There was a previous PR that briefly touched on how to spec this, see this [comment](https://github.com/WICG/fenced-frame/pull/176#discussion_r1881105124).


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/xiaochen-z/fenced-frame/pull/215.html" title="Last updated on Mar 27, 2025, 2:12 PM UTC (b9d5866)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/fenced-frame/215/9e3e56c...xiaochen-z:b9d5866.html" title="Last updated on Mar 27, 2025, 2:12 PM UTC (b9d5866)">Diff</a>