### PR TITLE
[Spec] Network revocation patches for Reporting API and Signed Exchange Reports

### DIFF
--- a/spec.bs
+++ b/spec.bs
@@ -221,6 +221,8 @@ spec: fetch; urlPrefix: https://fetch.spec.whatwg.org/
   type: dfn
     text: queue a cross-origin embedder policy CORP violation report; url: queue-a-cross-origin-embedder-policy-corp-violation-report
     text: should request be blocked due to a bad port; url: block-bad-port
+    for: request
+      text: determine the network partition key; url: request-determine-the-network-partition-key
     for: response
       text: has-cross-origin-redirects; url: response-has-cross-origin-redirects
 spec: mixed-content; urlPrefix: https://w3c.github.io/webappsec-mixed-content/
@@ -2178,7 +2180,8 @@ Once that web driver changes is made, existing Chromium-internal web platform te
   To determine whether fetching a [=request=] |request| <dfn>must be blocked due to
   a revoked partition nonce</dfn>, run these steps:
 
-  1. Let |nonce| be the result of running [=determine the network partition key=] on |request|.
+  1. Let |nonce| be the result of running [=request/determine the network partition key=] on
+     |request|.
 
   1. If the user agent's [=network revocation exemption map=][|nonce|] [=map/exists=], and if
      |request|'s [=request/URL=] [=set/exists=] in it, return <b>allowed</b>.

--- a/spec.bs
+++ b/spec.bs
@@ -4425,7 +4425,7 @@ Add the following algorithm:
 </div>
 
 <div algorithm=network-partition-key-patch>
-  Rewrite the [=network partition key=] redefinition to read:
+  Rewrite the [=network partition key=] <a href=https://wicg.github.io/anonymous-iframe/#spec-network-partition-key>redefinition</a> to read:
 
   A [=network partition key=] is a [=tuple=] consisting of:
 

--- a/spec.bs
+++ b/spec.bs
@@ -4429,9 +4429,9 @@ Add the following algorithm:
 
   A [=network partition key=] is a [=tuple=] consisting of:
 
-  - a [=site=].
-  - null or an [=implementation-defined=] value.
-  - a <dfn for="network partition key">nonce</dfn> (null or an [=implementation-defined=] value).
+  * a [=site=].
+  * null or an [=implementation-defined=] value.
+  * a <dfn for="network partition key">nonce</dfn> (null or an [=implementation-defined=] value).
 </div>
 
 <div algorithm="create navigation params by fetching">

--- a/spec.bs
+++ b/spec.bs
@@ -269,6 +269,9 @@ spec: attribution-reporting; urlPrefix: https://wicg.github.io/attribution-repor
 spec: turtledove; urlPrefix: https://wicg.github.io/turtledove/
   type: dfn
     text: construct a pending fenced frame config; url: construct-a-pending-fenced-frame-config
+spec: webpackage; urlPrefix: https://wicg.github.io/webpackage/loading.html
+  type: dfn
+    text: wait and queue a report for; url: wait-and-queue-a-report-for
 </pre>
 
 <style>
@@ -2201,11 +2204,12 @@ The network revocation mechanism requires the following monkeypatches to the [[H
   The network revocation mechanism requires the following monkeypatch to the [[Webpackage]]
   Standard.
 
-  Modify the [=generate and queue a report=] algorithm. Add a new step after step 1 that
-  reads:
+  Modify the [monkeypatch](https://wicg.github.io/webpackage/loading.html#mp-http-fetch) to [=HTTP
+  fetch=]. Rewrite step 4 under the **"b2" or "b3"** switch case to read:
 
-  2. If |context| is a {{Document}}, and if the result of running [=determine if a navigable has
-     revoked network for itself=] given |context|'s [=node navigable=] is true, then return.
+  PAHACER: add a check for nonce most likely. I don't think we have access to the document at this point.
+
+  4. [=In parallel=], [=wait and queue a report for=] <var ignore>parsedExchange</var> and <var ignore>report</var>.
 
 <h3 id=new-request-destination>New [=request=] [=request/destination=]</h3>
 

--- a/spec.bs
+++ b/spec.bs
@@ -2175,12 +2175,13 @@ Once that web driver changes is made, existing Chromium-internal web platform te
 </div>
 
 <div algorithm>
-  To determine whether fetching a [=request=] <var ignore>request</var> <dfn>must be blocked due to
-  a revoked partition nonce</dfn> using a [=fenced frame config instance/partition nonce=] |nonce|
-  and a [=URL=] |requestURL|, run these steps:
+  To determine whether fetching a [=request=] |request| <dfn>must be blocked due to
+  a revoked partition nonce</dfn>, run these steps:
+
+  1. Let |nonce| be the result of running [=determine the network partition key=] on |request|.
 
   1. If the user agent's [=network revocation exemption map=][|nonce|] [=map/exists=], and if
-     |requestURL| [=set/exists=] in it, return <b>allowed</b>.
+     |request|'s [=request/URL=] [=set/exists=] in it, return <b>allowed</b>.
 
   1. If the user agent's [=network revocation nonce set=] [=set/contains=] |nonce|, return
      <b>blocked</b>.
@@ -2254,30 +2255,28 @@ Standard.
      <var ignore>transport</var> to run these steps:
 </div>
 
-<h3 id=disable-reporting>Reporting API monkeypatches for network revocation</h3>
+The network revocation mechanism requires the following monkeypatch to the [[Reporting]]
+Standard.
 
-  The network revocation mechanism requires the following monkeypatch to the [[Reporting]]
-  Standard.
-
+<div algorithm=generate-report-patch>
   Modify the [=generate and queue a report=] algorithm. Add a new step after step 1 that
   reads:
 
   2. If |context| is a {{Document}}, and if the result of running [=determine if a navigable has
-     revoked network for itself=] given |context|'s [=node navigable=] is true, then return.
+      revoked network for itself=] given |context|'s [=node navigable=] is true, then return.
+</div>
 
-<h3 id=disable-sxg>Signed Exchange Reporting monkeypatches for network revocation</h3>
+The network revocation mechanism requires the following monkeypatch to the [[Webpackage]]
+Standard.
 
-  PAHACER: update this section
-
-  The network revocation mechanism requires the following monkeypatch to the [[Webpackage]]
-  Standard.
-
+<div algorithm=sxg-patch>
   Modify the [monkeypatch](https://wicg.github.io/webpackage/loading.html#mp-http-fetch) to [=HTTP
   fetch=]. Rewrite step 4 under the **"b2" or "b3"** switch case to read:
 
-  PAHACER: add a check for nonce most likely. I don't think we have access to the document at this point.
-
-  4. [=In parallel=], [=wait and queue a report for=] <var ignore>parsedExchange</var> and <var ignore>report</var>.
+  4. If the result of determining whether <var ignore>request</var> [=must be blocked due to a
+      revoked partition nonce=] is false, then [=in parallel=], [=wait and queue a report for=] <var
+      ignore>parsedExchange</var> and <var ignore>report</var>.
+</div>
 
 <h3 id=new-request-destination>New [=request=] [=request/destination=]</h3>
 

--- a/spec.bs
+++ b/spec.bs
@@ -2183,6 +2183,30 @@ The network revocation mechanism requires the following monkeypatches to the [[F
 
 The network revocation mechanism requires the following monkeypatches to the [[HTML]] Standard.
 
+<h3 id=disable-reporting>Reporting API monkeypatches for network revocation</h3>
+
+  The network revocation mechanism requires the following monkeypatch to the [[Reporting]]
+  Standard.
+
+  Modify the [=generate and queue a report=] algorithm. Add a new step after step 1 that
+  reads:
+
+  2. If |context| is a {{Document}}, and if the result of running [=determine if a navigable has
+     revoked network for itself=] given |context|'s [=node navigable=] is true, then return.
+
+<h3 id=disable-sxg>Signed Exchange Reporting monkeypatches for network revocation</h3>
+
+  PAHACER: update this section
+
+  The network revocation mechanism requires the following monkeypatch to the [[Webpackage]]
+  Standard.
+
+  Modify the [=generate and queue a report=] algorithm. Add a new step after step 1 that
+  reads:
+
+  2. If |context| is a {{Document}}, and if the result of running [=determine if a navigable has
+     revoked network for itself=] given |context|'s [=node navigable=] is true, then return.
+
 <h3 id=new-request-destination>New [=request=] [=request/destination=]</h3>
 
 The processing model of a <{fencedframe}>'s navigation request deviates from that of the normal
@@ -2240,6 +2264,22 @@ defined in the [[Shared-Storage]] draft specification.
 
   1. If |config|'s [=fenced frame config instance/untrusted network status=] is not [=untrusted
      network status/disabled for this tree and fenced subtrees=], return false.
+
+  1. Return true.
+</div>
+
+<div algorithm>
+  To <dfn>determine if a navigable has revoked network for itself</dfn> given a [=navigable=] 
+  |navigable|:
+
+  1. If |navigable|'s [=navigable/traversable navigable=] is not a [=fenced navigable
+     container/fenced navigable=], return false.
+
+  1. Let |config| be |navigable|'s [=navigable/active browsing context=]'s [=browsing
+     context/fenced frame config instance=].
+
+  1. If |config|'s [=fenced frame config instance/untrusted network status=] is [=untrusted network
+     status/enabled=], return false.
 
   1. Return true.
 </div>

--- a/spec.bs
+++ b/spec.bs
@@ -4429,9 +4429,9 @@ Add the following algorithm:
 
   A [=network partition key=] is a [=tuple=] consisting of:
 
-  - a [=site=].
-  - null or an [=implementation-defined=] value.
-  - a <dfn for="network partition key">nonce</dfn> (null or an [=implementation-defined=] value).
+    - a [=site=].
+    - null or an [=implementation-defined=] value.
+    - a <dfn for="network partition key">nonce</dfn> (null or an [=implementation-defined=] value).
 </div>
 
 <div algorithm="create navigation params by fetching">

--- a/spec.bs
+++ b/spec.bs
@@ -4425,7 +4425,8 @@ Add the following algorithm:
 </div>
 
 <div algorithm=network-partition-key-patch>
-  Rewrite the [=network partition key=] <a href=https://wicg.github.io/anonymous-iframe/#spec-network-partition-key>redefinition</a> to read:
+  Rewrite the [=network partition key=] <a
+  href=https://wicg.github.io/anonymous-iframe/#spec-network-partition-key>redefinition</a> to read:
 
   A [=network partition key=] is a [=tuple=] consisting of:
 

--- a/spec.bs
+++ b/spec.bs
@@ -2180,8 +2180,10 @@ Once that web driver changes is made, existing Chromium-internal web platform te
   To determine whether fetching a [=request=] |request| <dfn>must be blocked due to
   a revoked partition nonce</dfn>, run these steps:
 
-  1. Let |nonce| be the result of running [=request/determine the network partition key=] on
+  1. Let |key| be the result of running [=request/determine the network partition key=] on
      |request|.
+
+  1. Let |nonce| be |key|'s [=network partition key/nonce=].
 
   1. If the user agent's [=network revocation exemption map=][|nonce|] [=map/exists=], and if
      |request|'s [=request/URL=] [=set/exists=] in it, return <b>allowed</b>.
@@ -4343,6 +4345,18 @@ at the expense of some utility.
   <wpt>
     /fenced-frame/scroll-into-view.https.html
   </wpt>
+</div>
+
+<h3 id=credentialless-monkeypatch>Iframe credentialless</h3>
+
+<div algorithm=network-partition-key-patch>
+  Rewrite the [=network partition key=] redefinition to read:
+
+  A [=network partition key=] is a [=tuple=] consisting of:
+
+  - a [=site=].
+  - null or an [=implementation-defined=] value.
+  - A <dfn for="network partition key">nonce</dfn> (null or an [=implementation-defined=] value).
 </div>
 
 <h3 id=webrtc-monkeypatch>WebRTC</h3>

--- a/spec.bs
+++ b/spec.bs
@@ -2214,8 +2214,8 @@ Once that web driver changes is made, existing Chromium-internal web platform te
 </div>
 
 <div algorithm>
-  To determine whether fetching a [=request=] |request| <dfn>must be blocked due to
-  a revoked partition nonce</dfn>, run these steps:
+  To determine whether fetching a [=request=] |request| <dfn>must be blocked due to a revoked
+  partition nonce</dfn>, run these steps:
 
   1. Let |key| be the result of running [=request/determine the network partition key=] on
      |request|.
@@ -2297,27 +2297,24 @@ Standard.
      <var ignore>transport</var> to run these steps:
 </div>
 
-The network revocation mechanism requires the following monkeypatch to the [[Reporting]]
-Standard.
+The network revocation mechanism requires the following monkeypatch to the [[Reporting]] Standard.
 
 <div algorithm=generate-report-patch>
-  Modify the [=generate and queue a report=] algorithm. Add a new step after step 1 that
-  reads:
+  Modify the [=generate and queue a report=] algorithm. Add a new step after step 1 that reads:
 
   2. If |context| is a {{Document}}, and if the result of running [=determine if a navigable has
-      revoked network for itself=] given |context|'s [=node navigable=] is true, then return.
+     revoked network for itself=] given |context|'s [=node navigable=] is true, then return.
 </div>
 
-The network revocation mechanism requires the following monkeypatch to the [[Webpackage]]
-Standard.
+The network revocation mechanism requires the following monkeypatch to the [[Webpackage]] Standard.
 
 <div algorithm=sxg-patch>
   Modify the [monkeypatch](https://wicg.github.io/webpackage/loading.html#mp-http-fetch) to [=HTTP
   fetch=]. Rewrite step 4 under the **"b2" or "b3"** switch case to read:
 
   4. If the result of determining whether <var ignore>request</var> [=must be blocked due to a
-      revoked partition nonce=] is false, then [=in parallel=], [=wait and queue a report for=] <var
-      ignore>parsedExchange</var> and <var ignore>report</var>.
+     revoked partition nonce=] is false, then [=in parallel=], [=wait and queue a report for=] <var
+     ignore>parsedExchange</var> and <var ignore>report</var>.
 </div>
 
 <h3 id=new-request-destination>New [=request=] [=request/destination=]</h3>
@@ -4434,7 +4431,7 @@ Add the following algorithm:
 
   - a [=site=].
   - null or an [=implementation-defined=] value.
-  - A <dfn for="network partition key">nonce</dfn> (null or an [=implementation-defined=] value).
+  - a <dfn for="network partition key">nonce</dfn> (null or an [=implementation-defined=] value).
 </div>
 
 <div algorithm="create navigation params by fetching">

--- a/spec.bs
+++ b/spec.bs
@@ -4429,9 +4429,9 @@ Add the following algorithm:
 
   A [=network partition key=] is a [=tuple=] consisting of:
 
-    - a [=site=].
-    - null or an [=implementation-defined=] value.
-    - a <dfn for="network partition key">nonce</dfn> (null or an [=implementation-defined=] value).
+  - a [=site=].
+  - null or an [=implementation-defined=] value.
+  - a <dfn for="network partition key">nonce</dfn> (null or an [=implementation-defined=] value).
 </div>
 
 <div algorithm="create navigation params by fetching">


### PR DESCRIPTION
This spec patch does the following:

- Modifies the "generate and queue a report" to early return if invoked from documents within a fenced frame tree with its network access revoked.
- Modifies the Webpackage signed exchange reporting API to only queue a report if the request's associated partition nonce is not one of the revoked nonces.
  - Note that this spec is on hold and most likely not going to become a standard, but we are still adding this patch in to cover all our bases.
- Modifies the "must be blocked due to a revoked partition nonce" algorithm to look for the nonce and URL in the request object, rather than expecting one to be provided.
  - This should be fine because the algorithm that [pulls the nonce from the request object](https://fetch.spec.whatwg.org/#request-determine-the-network-partition-key) ultimately gets that from the [request's associated environment](https://wicg.github.io/anonymous-iframe/#spec-network-partition-key). That nonce is set [when the environment is first created](https://wicg.github.io/anonymous-iframe/#spec-navigation-partition-nonce), and we have a patch to [conditionally set it to the fenced frame's network revocation nonce](https://github.com/WICG/fenced-frame/pull/149).
- Makes the "nonce" addition to the [network partition key definition in the credentialless iframes spec](https://wicg.github.io/anonymous-iframe/#spec-network-partition-key) more well defined.

https://github.com/WICG/fenced-frame/pull/149 should be merged in before this PR so that the logic that sets the environment's partition nonce to the fenced frame nonce is in place.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/WICG/fenced-frame/pull/216.html" title="Last updated on Mar 25, 2025, 1:38 PM UTC (e099656)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/fenced-frame/216/01a8212...e099656.html" title="Last updated on Mar 25, 2025, 1:38 PM UTC (e099656)">Diff</a>