### PR TITLE
Remove canLoadOpaqueURL() from explainer.

### DIFF
--- a/explainer/README.md
+++ b/explainer/README.md
@@ -126,29 +126,6 @@ There are many channels between the fenced frame tree and the other frames that 
 
 This discussion assumes that third-party cookies, like all other third party storage,  are also [disallowed](https://blog.chromium.org/2020/01/building-more-private-web-path-towards.html) or else those would be a communication channel between the fenced frame and the embedding site.
 
-### HTMLFencedFrameElement class
-
-All fenced frame related functions will live in its own class, in the same way that iframe-related funcionality lives in HTMLIFrameElement.
-
-#### Can Load API
-
-There are various reasons a fenced frame config with an opaque url could refuse to load in a page. For example, if the page is not in a secure context, or if CSPEE is specified in the embedding frame, the fenced frame config will refuse to load. This is a lot for a developer to keep track of.
-
-If the process of getting an ad in the page is complex or expensive, there needs to be a way to ensure that the resulting ad will actually end up in the page before the expensive process begins.
-
-A static API method will be introduced to the HTMLFencedFrameElement class to check this. No fenced frame will be created when calling this API, and it can be invoked before actually attempting to load a fenced frame config. The API will return a boolean, true if a config with an opaque mapped url would be able to load in the caller's context, false if not.
-
-##### Example usage
-
-```
-HTMLFencedFrameElement.canLoadOpaqueURL();
-```
-```
-> true
-```
-
-This is called synchronously, and will look at the execution context of the frame invoking the API.
-
 ## Security considerations
 
 Even though a fenced frame is isolated from its embedding context, it cannot be used as a workaround to the security restrictions that the top-level site wants to enforce on the embedding frames, without the knowledge of the top-level site. The design decisions of fenced frames related to security mechanisms like sandbox, csp, permission policy etc. are based on the following principles:


### PR DESCRIPTION
`canLoadOpaqueURL()` has been deprecated for years and has been replaced by `navigator.canLoadAdAuctionFencedFrame()`, which is documented [in the Protected Audience spec](https://wicg.github.io/turtledove/#canloadadauctionfencedframe).