### PR TITLE
Add new history WPT

### DIFF
--- a/spec.bs
+++ b/spec.bs
@@ -3480,6 +3480,7 @@ CORP violation report=] algorithm, as leaving it unfenced may cause a privacy le
     /fenced-frame/history-back-and-forward-should-not-work-in-fenced-tree.https.html
     /fenced-frame/history-length-fenced-navigations-replace-do-not-contribute-to-joint.https.html
     /fenced-frame/history-length-outer-page-navigation-not-reflected-in-fenced.https.html
+    /fenced-frame/history-length-outer-page-navigation-not-reflected-in-fenced-nested-iframe.https.html
   </wpt>
 </div>
 


### PR DESCRIPTION
`history-length-outer-page-navigation-not-reflected-in-fenced-nested-iframe` was split off from `history-length-outer-page-navigation-not-reflected-in-fenced`. Add the new test to the spec.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/WICG/fenced-frame/pull/229.html" title="Last updated on Apr 4, 2025, 6:05 PM UTC (25e3563)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/fenced-frame/229/c628f90...25e3563.html" title="Last updated on Apr 4, 2025, 6:05 PM UTC (25e3563)">Diff</a>